### PR TITLE
Adjust record versioning and tags

### DIFF
--- a/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Services/Oid4VciClientService/DefaultOid4VciClientService.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Services/Oid4VciClientService/DefaultOid4VciClientService.cs
@@ -43,7 +43,12 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
         {
             var httpClient = _httpClientFactory.CreateClient();
             
-            var baseEndpoint = endpoint.AbsolutePath.EndsWith("/") ? endpoint : new Uri(endpoint.OriginalString + "/");
+            var baseEndpoint = endpoint
+                .AbsolutePath
+                .EndsWith("/") 
+                ? endpoint 
+                : new Uri(endpoint.OriginalString + "/");
+            
             var metadataUrl = new Uri(baseEndpoint, ".well-known/openid-credential-issuer");
 
             var response = await httpClient.GetAsync(metadataUrl);

--- a/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/OidPresentationRecord.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/OidPresentationRecord.cs
@@ -56,11 +56,11 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Models
         /// <summary>
         ///     Constructor for Serialization.
         /// </summary>
-        /// <param name="clientId"></param>
-        /// <param name="id"></param>
-        /// <param name="clientMetadata"></param>
-        /// <param name="name"></param>
-        /// <param name="presentedCredentials"></param>
+        /// <param name="presentedCredentials">The credentials the Holder presented to the Verifier.</param>
+        /// <param name="clientId">The client id for the Verifier.</param>
+        /// <param name="id">The id of the record.</param>
+        /// <param name="clientMetadata">The metadata of the Verifier.</param>
+        /// <param name="name">The name of the presentation.</param>
         [JsonConstructor]
         private OidPresentationRecord(
             PresentedCredential[] presentedCredentials,

--- a/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/OidPresentationRecord.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/OidPresentationRecord.cs
@@ -17,7 +17,12 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Models
         /// <summary>
         ///     Gets or sets the client id and identifies the Verifier.
         /// </summary>
-        public string ClientId { get; }
+        [JsonIgnore]
+        public string ClientId
+        {
+            get => Get();
+            set => Set(value, false);
+        }
 
         /// <summary>
         ///     Gets or sets the type name.
@@ -27,16 +32,27 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Models
         /// <summary>
         ///     Gets or sets the metadata of the Verifier.
         /// </summary>
-        public string? ClientMetadata { get; }
+        public string? ClientMetadata { get; set; }
 
         /// <summary>
         ///     Gets or sets the name of the presentation.
         /// </summary>
-        public string? Name { get; }
+        [JsonIgnore]
+        public string? Name
+        {
+            get => Get();
+            set
+            {
+                if (value is not null)
+                {
+                    Set(value, false);
+                }
+            }
+        }
 
 #pragma warning disable CS8618
         /// <summary>
-        ///     This constructor is required for the record service but should not actually be used.
+        ///     Parameterless Default Constructor.
         /// </summary>
         public OidPresentationRecord()
         {
@@ -44,26 +60,26 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Models
 #pragma warning restore CS8618
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="OidPresentationRecord" /> class.
+        ///     Constructor for Serialization.
         /// </summary>
         /// <param name="clientId"></param>
+        /// <param name="id"></param>
         /// <param name="clientMetadata"></param>
         /// <param name="name"></param>
         /// <param name="presentedCredentials"></param>
         [JsonConstructor]
-        public OidPresentationRecord(
+        private OidPresentationRecord(
+            PresentedCredential[] presentedCredentials,
             string clientId,
+            string id,
             string? clientMetadata,
-            string? name,
-            PresentedCredential[] presentedCredentials)
+            string? name)
         {
             ClientId = clientId;
             ClientMetadata = clientMetadata;
-            CreatedAtUtc = DateTime.UtcNow;
-            Id = Guid.NewGuid().ToString();
+            Id = id;
             Name = name;
             PresentedCredentials = presentedCredentials;
-            RecordVersion = 1;
         }
     }
 }

--- a/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/OidPresentationRecord.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/OidPresentationRecord.cs
@@ -41,13 +41,7 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Models
         public string? Name
         {
             get => Get();
-            set
-            {
-                if (value is not null)
-                {
-                    Set(value, false);
-                }
-            }
+            set => Set(value!, false);
         }
 
 #pragma warning disable CS8618

--- a/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Services/Oid4VpRecordService.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Services/Oid4VpRecordService.cs
@@ -48,11 +48,14 @@ namespace Hyperledger.Aries.Features.OpenID4VC.Vp.Services
             string? name,
             PresentedCredential[] presentedCredentials)
         {
-            var record = new OidPresentationRecord(
-                clientId,
-                clientMetadata,
-                name,
-                presentedCredentials);
+            var record = new OidPresentationRecord
+            {
+                ClientId = clientId,
+                ClientMetadata = clientMetadata,
+                Id = Guid.NewGuid().ToString(),
+                PresentedCredentials = presentedCredentials,
+                RecordVersion = 1
+            };
             
             await RecordService.AddAsync(context.Wallet, record);
             

--- a/src/Hyperledger.Aries/Features/SdJwt/Services/SdJwtVcHolderService/DefaultSdJwtVcHolderService.cs
+++ b/src/Hyperledger.Aries/Features/SdJwt/Services/SdJwtVcHolderService/DefaultSdJwtVcHolderService.cs
@@ -147,10 +147,13 @@ namespace Hyperledger.Aries.Features.SdJwt.Services.SdJwtVcHolderService
         {
             var sdJwtDoc = Holder.ReceiveCredential(combinedIssuance);
             var record = SdJwtRecord.FromSdJwtDoc(sdJwtDoc);
-            record.Id = Guid.NewGuid().ToString();
 
             record.SetDisplayFromIssuerMetadata(issuerMetadata, credentialMetadataId);
+            
+            record.Id = Guid.NewGuid().ToString();
             record.KeyId = keyId;
+
+            record.RecordVersion = 1;
 
             await RecordService.AddAsync(context.Wallet, record);
 

--- a/src/Hyperledger.Aries/Storage/Records/RecordBase.cs
+++ b/src/Hyperledger.Aries/Storage/Records/RecordBase.cs
@@ -17,7 +17,7 @@ namespace Hyperledger.Aries.Storage
         /// <returns>The created datetime of the record.</returns>
         public DateTime? CreatedAtUtc
         {
-            get => GetDateTime();
+            get => GetDateTimeUtc();
             set => Set(value, false);
         }
 
@@ -27,7 +27,7 @@ namespace Hyperledger.Aries.Storage
         /// <returns>The last updated datetime of the record.</returns>
         public DateTime? UpdatedAtUtc
         {
-            get => GetDateTime();
+            get => GetDateTimeUtc();
             set => Set(value, false);
         }
         
@@ -132,14 +132,16 @@ namespace Hyperledger.Aries.Storage
         /// <summary>Gets the date time.</summary>
         /// <param name="name">The name.</param>
         /// <returns></returns>
-        protected DateTime? GetDateTime([CallerMemberName] string name = "")
+        protected DateTime? GetDateTimeUtc([CallerMemberName] string name = "")
         {
             var strVal = Get(name);
 
             if (strVal == null)
                 return null;
 
-            return new DateTime(Convert.ToInt64(strVal));
+            var result = new DateTime(Convert.ToInt64(strVal));
+            
+            return DateTime.SpecifyKind(result, DateTimeKind.Utc);
         }
 
         /// <summary>


### PR DESCRIPTION
#### Short description of what this resolves:

Mainly moved some Properties of the SdJwt and Presentation-Records to Tags so it can be used in SearchQuerys. 

Also moved RecordVersion to Tags, because this could become useful for migration purposes in the future.

#### Changes proposed in this pull request:

- See above
-
-

**Fixes**: /
