### PR TITLE
Add support for fork PRs

### DIFF
--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -11,13 +11,13 @@ on:
 env:
     BUILD_CONFIG: 'Release'
     SOLUTION: 'src/Hyperledger.Aries.sln'
-    IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+    IS_PULL_REQUEST: ${{ github.event_name == 'pull_request_target' }}
     IS_MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
     authorize:
         environment:
-            ${{ github.event_name == 'pull_request_target' &&
+            ${{ IS_PULL_REQUEST &&
             github.event.pull_request.head.repo.full_name != github.repository &&
             'external' || 'internal' }}
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -4,7 +4,7 @@ on:
     push:
         branches:
             - main
-    pull_request:
+    pull_request_target:
         branches:
             - main
 
@@ -15,10 +15,18 @@ env:
     IS_MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
-    build:
-        
+    authorize:
+        environment:
+            ${{ github.event_name == 'pull_request_target' &&
+            github.event.pull_request.head.repo.full_name != github.repository &&
+            'external' || 'internal' }}
         runs-on: ubuntu-latest
-        
+        steps:
+            - run: "true"
+              
+    build:
+        needs: authorize
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
         


### PR DESCRIPTION
#### Short description of what this resolves:
This PR adds an authorize job to the pipeline which requires trusted Maintainers to approve a pipeline run whenever a pull request from a fork is introduced. This way, upon approval the pipeline can use the nuget API secret and publish new builds because of the pull_request_target trigger without introducing security vulnerabilities.

#### Changes proposed in this pull request:

- publish-nuget.yaml

