### PR TITLE
Expose request object certificate in authorization request

### DIFF
--- a/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/RequestObject.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/RequestObject.cs
@@ -10,6 +10,7 @@ using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 using static Hyperledger.Aries.Features.OpenId4Vc.Vp.Models.AuthorizationRequest;
 using static Newtonsoft.Json.Linq.JArray;
 using static System.Convert;
+using static Hyperledger.Aries.Features.OpenId4Vc.Vp.Models.ClientIdScheme.ClientIdSchemeValue;
 
 namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Models
 {
@@ -108,7 +109,7 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Models
                 ? requestObject
                 : throw new InvalidOperationException("Validation of trust chain failed");
 
-        private static List<X509Certificate> GetCertificates(this RequestObject requestObject) =>
+        internal static List<X509Certificate> GetCertificates(this RequestObject requestObject) =>
             Parse(((JwtSecurityToken)requestObject).Header.X5c)
                 .Select(
                     certAsJToken =>
@@ -119,7 +120,7 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Models
                 )
                 .ToList();
 
-        private static X509Certificate GetLeafCertificate(this RequestObject requestObject) =>
+        internal static X509Certificate GetLeafCertificate(this RequestObject requestObject) =>
             GetCertificates(requestObject).First();
     }
 }

--- a/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/RequestObject.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Models/RequestObject.cs
@@ -10,7 +10,6 @@ using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 using static Hyperledger.Aries.Features.OpenId4Vc.Vp.Models.AuthorizationRequest;
 using static Newtonsoft.Json.Linq.JArray;
 using static System.Convert;
-using static Hyperledger.Aries.Features.OpenId4Vc.Vp.Models.ClientIdScheme.ClientIdSchemeValue;
 
 namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Models
 {

--- a/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Services/Oid4VpHaipClient.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/Vp/Services/Oid4VpHaipClient.cs
@@ -84,7 +84,8 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vp.Services
                             .ValidateJwt()
                             .ValidateTrustChain()
                             .ValidateSanName()
-                            .ToAuthorizationRequest(),
+                            .ToAuthorizationRequest()
+                            .WithX509(requestObject),
                     RedirectUri =>
                         requestObject.ToAuthorizationRequest(),
                     VerifierAttestation =>

--- a/src/Hyperledger.Aries/IsExternalInit.cs
+++ b/src/Hyperledger.Aries/IsExternalInit.cs
@@ -1,0 +1,8 @@
+namespace System.Runtime.CompilerServices
+{
+    // This is needed for the init property setter. This can be removed when updating to a newer C# Version.
+    // https://stackoverflow.com/questions/64749385/predefined-type-system-runtime-compilerservices-isexternalinit-is-not-defined
+    internal static class IsExternalInit
+    {
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

Exposes the certificate of the request object so that the framework consumer can view it.
