### PR TITLE
add userPin

### DIFF
--- a/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Models/Authorization/TokenRequest.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Models/Authorization/TokenRequest.cs
@@ -31,10 +31,16 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Models.Authorization
         public string? Scope { get; set; }
 
         /// <summary>
+        ///     Gets or sets the transaction code. This value must be present if a transaction code was required in a previous step.
+        /// </summary>
+        [JsonProperty("tx_code", NullValueHandling = NullValueHandling.Ignore)]
+        public string? TransactionCode { get; set; }
+        
+        /// <summary>
         ///     Gets or sets the user PIN. This value must be present if a PIN was required in a previous step.
         /// </summary>
-        [JsonProperty("tx_code")]
-        public string? TransactionCode { get; set; }
+        [JsonProperty("user_pin", NullValueHandling = NullValueHandling.Ignore)]
+        public string? UserPin { get; set; }
 
         /// <summary>
         ///     Converts the properties of the TokenRequest instance into an FormUrlEncodedContent type suitable for HTTP POST

--- a/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Models/CredentialOffer/GrantTypes/PreAuthorizedCode.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Models/CredentialOffer/GrantTypes/PreAuthorizedCode.cs
@@ -21,6 +21,12 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Models.CredentialOffer.GrantT
         /// </summary>
         [JsonProperty("tx_code")]
         public TransactionCode? TransactionCode { get; set; }
+        
+        /// <summary>
+        ///     Specifying whether the user must send a User Pin along with the Token Request in a Pre-Authorized Code Flow.
+        /// </summary>
+        [JsonProperty("user_pin_required")]
+        public bool? UserPinRequired { get; set; }
     }
 
     /// <summary>

--- a/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Services/Oid4VciClientService/IOid4VciClientService.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Services/Oid4VciClientService/IOid4VciClientService.cs
@@ -26,7 +26,8 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
         /// <param name="credentialMetadata">The credential metadata.</param>
         /// <param name="issuerMetadata">The issuer metadata.</param>
         /// <param name="preAuthorizedCode">The pre-authorized code for token request.</param>
-        /// /// <param name="transactionCode">The Transaction Code.</param>
+        /// <param name="transactionCode">The Transaction Code.</param>
+        /// <param name="userPin">The User Pin.</param>
         /// <returns>
         ///     A tuple containing the credential response and the key ID used during the signing of the Proof of Possession.
         /// </returns>
@@ -34,7 +35,8 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
             OidCredentialMetadata credentialMetadata,
             OidIssuerMetadata issuerMetadata,
             string preAuthorizedCode,
-            string? transactionCode
+            string? transactionCode,
+            string? userPin
         );
     }
 }

--- a/test/Hyperledger.Aries.Tests/Features/OpenId4Vc/Vci/Services/Oid4VciClientServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/Features/OpenId4Vc/Vci/Services/Oid4VciClientServiceTests.cs
@@ -133,7 +133,8 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
                     _oidIssuerMetadata.CredentialsSupported.First().Value,
                     _oidIssuerMetadata,
                     PreAuthorizedCode,
-                    TransactionCode
+                    TransactionCode,
+                    null
                     );
             
             //Assert
@@ -171,7 +172,8 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
                     _oidIssuerMetadata.CredentialsSupported.First().Value,
                     _oidIssuerMetadata,
                     PreAuthorizedCode,
-                    TransactionCode
+                    TransactionCode,
+                    null
                 );
             
             //Assert


### PR DESCRIPTION
#### Short description of what this resolves:
This PR reintroduces the userPin from the Oid4Vci draft 12. Now the framework can handle tx_codes and userPins whatever the issuer chooses to use.