### PR TITLE
Add sd_hash field to KbJwt

### DIFF
--- a/src/Hyperledger.Aries/Features/OpenID4VC/KeyStore/Services/IKeyStore.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/KeyStore/Services/IKeyStore.cs
@@ -25,11 +25,12 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.KeyStore.Services
         ///     A unique token, typically used to prevent replay attacks by ensuring that the proof is only used once.
         /// </param>
         /// <param name="type">The type of the proof. (For example "openid4vci-proof+jwt")</param>
+        /// <param name="sdHash">Base64url-encoded hash digest over the Issuer-signed JWT and the selected Disclosures for integrity protection</param>
         /// <returns>
         ///     A <see cref="Task{TResult}" /> representing the asynchronous operation. When evaluated, the task's result contains
         ///     the proof.
         /// </returns>
-        Task<string> GenerateKbProofOfPossessionAsync(string keyId, string audience, string nonce, string type);
+        Task<string> GenerateKbProofOfPossessionAsync(string keyId, string audience, string nonce, string type, string? sdHash = null);
         
         /// <summary>
         ///     Asynchronously creates a DPoP Proof JWT for a specific key, based on the provided audience, nonce and access token.

--- a/src/Hyperledger.Aries/Features/SdJwt/Services/SdJwtVcHolderService/DefaultSdJwtVcHolderService.cs
+++ b/src/Hyperledger.Aries/Features/SdJwt/Services/SdJwtVcHolderService/DefaultSdJwtVcHolderService.cs
@@ -67,16 +67,18 @@ namespace Hyperledger.Aries.Features.SdJwt.Services.SdJwtVcHolderService
                     disclosures.Add(deserializedDisclosure);
                 }
             }
+            
+            var presentationFormat = Holder.CreatePresentationFormat(credential.EncodedIssuerSignedJwt, disclosures.ToArray());
 
-            string? keybindingJwt = null;
             if (!string.IsNullOrEmpty(credential.KeyId) && !string.IsNullOrEmpty(nonce) &&
                 !string.IsNullOrEmpty(audience))
             {
-                keybindingJwt =
-                    await KeyStore.GenerateKbProofOfPossessionAsync(credential.KeyId, audience, nonce, "kb+jwt");
+                var keybindingJwt =
+                    await KeyStore.GenerateKbProofOfPossessionAsync(credential.KeyId, audience, nonce, "kb+jwt", presentationFormat.ToSdHash());
+                return presentationFormat.AddKeyBindingJwt(keybindingJwt);
             }
 
-            return Holder.CreatePresentation(credential.EncodedIssuerSignedJwt, disclosures.ToArray(), keybindingJwt);
+            return presentationFormat.Value;
         }
 
         /// <inheritdoc />

--- a/src/Hyperledger.Aries/Hyperledger.Aries.csproj
+++ b/src/Hyperledger.Aries/Hyperledger.Aries.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="Polly" Version="$(PollyVersion)" />
         <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-        <PackageReference Include="SD-JWT" Version="0.1.0-rc.44" />
+        <PackageReference Include="SD-JWT" Version="0.1.0-pr.8.45" />
         <PackageReference Include="Stateless" Version="$(StatelessVersion)" />
         <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />

--- a/src/Hyperledger.Aries/Hyperledger.Aries.csproj
+++ b/src/Hyperledger.Aries/Hyperledger.Aries.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="Polly" Version="$(PollyVersion)" />
         <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-        <PackageReference Include="SD-JWT" Version="0.1.0-pr.8.45" />
+        <PackageReference Include="SD-JWT" Version="0.1.0-rc.46" />
         <PackageReference Include="Stateless" Version="$(StatelessVersion)" />
         <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />

--- a/test/Hyperledger.Aries.Tests/Features/OpenId4Vc/Vci/Services/Oid4VciClientServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/Features/OpenId4Vc/Vci/Services/Oid4VciClientServiceTests.cs
@@ -117,7 +117,7 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
             SetupKeyStoreGenerateKeySequence(KeyBindingJwtKeyId);
             _keyStoreMock.Setup(j =>
                     j.GenerateKbProofOfPossessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-                        It.IsAny<string>()))
+                        It.IsAny<string>(),It.IsAny<string>()))
                 .ReturnsAsync(KbJwtMock);
             
             SetupHttpClientSequence(_authServerMetadataResponseWithoutDPopSupport, _tokenResponseWithoutDpopSupport, _credentialResponse);
@@ -147,7 +147,7 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
             SetupKeyStoreGenerateKeySequence(DPopJwtKeyId, KeyBindingJwtKeyId);
             _keyStoreMock.Setup(j =>
                     j.GenerateKbProofOfPossessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-                        It.IsAny<string>()))
+                        It.IsAny<string>(),It.IsAny<string>()))
                 .ReturnsAsync(KbJwtMock);
             _keyStoreMock.Setup(j =>
                     j.GenerateDPopProofOfPossessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),

--- a/test/Hyperledger.Aries.Tests/Features/SdJwt/SdJwtVcHolderTests.cs
+++ b/test/Hyperledger.Aries.Tests/Features/SdJwt/SdJwtVcHolderTests.cs
@@ -264,7 +264,7 @@ namespace Hyperledger.Aries.Tests.Features.SdJwt
                 throw new NotImplementedException();
             }
 
-            public Task<string> GenerateKbProofOfPossessionAsync(string keyId, string audience, string nonce, string type)
+            public Task<string> GenerateKbProofOfPossessionAsync(string keyId, string audience, string nonce, string type, string? sdHash)
             {
                 throw new NotImplementedException();
             }

--- a/test/Hyperledger.Aries.Tests/Integration/Oid4VpClientServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/Integration/Oid4VpClientServiceTests.cs
@@ -69,6 +69,7 @@ namespace Hyperledger.Aries.Tests.Integration
                         It.IsAny<string>(),
                         It.IsAny<string>(),
                         It.IsAny<string>(),
+                        It.IsAny<string>(),
                         It.IsAny<string>()
                     )
                 )


### PR DESCRIPTION
#### Short description of what this resolves:
This PR adjust the Interface of GenerateKbProofOfPossessionAsync and the flow during the creation process of the presentation format of the SdJwt which allows the wallet to add the sd_hash field to the KbJwt.
