### PR TITLE
Fix Serialization of Client Metadata

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Models/ClientMetadata.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Models/ClientMetadata.cs
@@ -40,6 +40,7 @@ public record ClientMetadata
     
     [JsonProperty("jwks")]
     [JsonConverter(typeof(ClientJwksConverter))]
+    [JsonIgnore]
     public List<JsonWebKey> Jwks { get; }
     
     /// <summary>


### PR DESCRIPTION
#### Short description of what this resolves:
- This PR adds JsonIgnore to the JWks in ClientMetadata to fix its serialization.
