### PR TITLE
Fix disclosureless Sd-Jwt

### DIFF
--- a/src/WalletFramework.SdJwtVc/WalletFramework.SdJwtVc.csproj
+++ b/src/WalletFramework.SdJwtVc/WalletFramework.SdJwtVc.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SD-JWT" Version="0.1.0-rc.63" />
+    <PackageReference Include="SD-JWT" Version="0.1.0-rc.65" />
   </ItemGroup>
 </Project>

--- a/src/WalletFramework.SdJwtVc/WalletFramework.SdJwtVc.csproj
+++ b/src/WalletFramework.SdJwtVc/WalletFramework.SdJwtVc.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SD-JWT" Version="0.1.0-rc.59" />
+    <PackageReference Include="SD-JWT" Version="0.1.0-rc.63" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
#### Short description of what this resolves:
- This PR bumps the version of the SD-JWT lib which introduces a bugfix for SD-JWTs without the _sd_alg property if it does do not offer disclosures.
