### PR TITLE
Fix Auth Server Selection

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
-    "rollForward": "latestFeature"
+    "version": "8.0.402",
+    "rollForward": "disable"
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
 Use the Auth Server Url referenced in the Cred Offer to find the appropriate Auth Server Url in the IssuerMetadata to fetch the Auth Server Metadata. If the Cred Offer references an Auth Server that is not part of the IssuerMetadata AuthServers the process should be aborted.
