### PR TITLE
bump polly from 7.2.1 to 8.5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,7 +50,7 @@
         <MultiformatsBaseVersion>2.0.2</MultiformatsBaseVersion>
         <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
         <NLogConfigVersion>4.7.2</NLogConfigVersion>
-        <PollyVersion>7.2.1</PollyVersion>
+        <PollyVersion>8.5.0</PollyVersion>
         <StatelessVersion>5.1.2</StatelessVersion>
         <SwashbuckleAspNetCoreAnnotationsVersion>5.5.1</SwashbuckleAspNetCoreAnnotationsVersion>
         <SwashbuckleAspNetCoreFiltersVersion>5.1.2</SwashbuckleAspNetCoreFiltersVersion>


### PR DESCRIPTION
#### Short description of what this resolves:

This PR bumps the Polly version to the latest stable.

#### Changes proposed in this pull request:

-
-
-

**Fixes**: #
