### PR TITLE
Extend the selection of Root Certificates in x509Chain

### DIFF
--- a/src/WalletFramework.Core/X509/X509CertificateExtensions.cs
+++ b/src/WalletFramework.Core/X509/X509CertificateExtensions.cs
@@ -21,9 +21,10 @@ public static class X509CertificateExtensions
     {
         var leafCert = trustChain.First();
 
+        var subjects = trustChain.Select(cert => cert.SubjectDN);
         var rootCerts = new HashSet(
             trustChain
-                .Where(cert => cert.IsSelfSigned())
+                .Where(cert => cert.IsSelfSigned() || !subjects.Contains(cert.IssuerDN))
                 .Select(cert => new TrustAnchor(cert, null)));
 
         var intermediateCerts = new HashSet(

--- a/src/WalletFramework.Core/X509/X509CertificateExtensions.cs
+++ b/src/WalletFramework.Core/X509/X509CertificateExtensions.cs
@@ -21,7 +21,7 @@ public static class X509CertificateExtensions
     {
         var leafCert = trustChain.First();
 
-        var subjects = trustChain.Select(cert => cert.SubjectDN);
+        var subjects = trustChain.Select(cert => cert.SubjectDN); 
         var rootCerts = new HashSet(
             trustChain
                 .Where(cert => cert.IsSelfSigned() || !subjects.Contains(cert.IssuerDN))


### PR DESCRIPTION
#### Short description of what this resolves:
This PR extends the selection of root certificates in the x509 chain of the x5c header.