### PR TITLE
Fix Encrypted Authorization Response

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/AuthResponse/Encryption/EncryptedAuthorizationResponse.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/AuthResponse/Encryption/EncryptedAuthorizationResponse.cs
@@ -7,12 +7,13 @@ using Org.BouncyCastle.Crypto.Modes;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
 using WalletFramework.Core.Base64Url;
+using WalletFramework.Core.Functional;
 using WalletFramework.Oid4Vc.Oid4Vp.Jwk;
 using WalletFramework.Oid4Vc.Oid4Vp.Models;
 
 namespace WalletFramework.Oid4Vc.Oid4Vp.AuthResponse.Encryption;
 
-public record EncryptedAuthorizationResponse(string Jwe)
+public record EncryptedAuthorizationResponse(string Jwe, Option<string> State)
 {
     public override string ToString() => Jwe;
 }
@@ -26,12 +27,14 @@ public static class EncryptedAuthorizationResponseFun
         response,
         authorizationRequest.ClientMetadata!.Jwks.First(),
         authorizationRequest.Nonce,
+        authorizationRequest.ClientMetadata.AuthorizationEncryptedResponseEnc,
         mdocNonce);
 
-    public static EncryptedAuthorizationResponse Encrypt(
+    private static EncryptedAuthorizationResponse Encrypt(
         this AuthorizationResponse response,
         JsonWebKey verifierPubKey,
         string apv,
+        Option<string> authorizationEncryptedResponseEnc,
         Option<Nonce> mdocNonce)
     {
         var apvBase64 = Base64UrlString.CreateBase64UrlString(apv.GetUTF8Bytes());
@@ -50,12 +53,17 @@ public static class EncryptedAuthorizationResponseFun
         var jwe = JWE.EncryptBytes(
             response.ToJson().GetUTF8Bytes(),
             new[] { new JweRecipient(JweAlgorithm.ECDH_ES, verifierPubKey.ToEcdh()) },
-            JweEncryption.A256GCM,
+            authorizationEncryptedResponseEnc.ToNullable() switch {
+                "A256GCM" => JweEncryption.A256GCM,
+                "A128CBC-HS256" => JweEncryption.A128CBC_HS256,
+                null => JweEncryption.A256GCM,
+                _ => throw new NotSupportedException("Unsupported response encryption algorithm requested by verifier.")
+            },
             mode: SerializationMode.Compact,
             extraProtectedHeaders: headers,
             settings: settings);
 
-        return new EncryptedAuthorizationResponse(jwe);
+        return new EncryptedAuthorizationResponse(jwe, response.State);
     }
 
     public static FormUrlEncodedContent ToFormUrl(this EncryptedAuthorizationResponse response)
@@ -64,6 +72,8 @@ public static class EncryptedAuthorizationResponseFun
         {
             { "response", response.ToString() }
         };
+
+        response.State.IfSome(state => content["state"] = state);
 
         return new FormUrlEncodedContent(content);
     }

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/AuthResponse/Encryption/EncryptedAuthorizationResponse.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/AuthResponse/Encryption/EncryptedAuthorizationResponse.cs
@@ -30,7 +30,7 @@ public static class EncryptedAuthorizationResponseFun
         authorizationRequest.ClientMetadata.AuthorizationEncryptedResponseEnc,
         mdocNonce);
 
-    private static EncryptedAuthorizationResponse Encrypt(
+    public static EncryptedAuthorizationResponse Encrypt(
         this AuthorizationResponse response,
         JsonWebKey verifierPubKey,
         string apv,

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Models/ClientMetadata.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Models/ClientMetadata.cs
@@ -9,6 +9,12 @@ namespace WalletFramework.Oid4Vc.Oid4Vp.Models;
 public record ClientMetadata
 {
     /// <summary>
+    ///     Defined the encoding that should be used when an encrypted Auth Response is requested by the verifier.
+    /// </summary>
+    [JsonProperty("authorization_encrypted_response_enc")]
+    public string? AuthorizationEncryptedResponseEnc { get; }
+    
+    /// <summary>
     ///    The redirect URIs of the client (verifier).
     /// </summary>
     [JsonProperty("redirect_uris")]
@@ -62,6 +68,7 @@ public record ClientMetadata
     public Formats Formats { get; }
 
     public ClientMetadata(
+        string? authorizationEncryptedResponseEnc,
         string? clientName,
         string? clientUri,
         string[]? contacts,
@@ -72,6 +79,7 @@ public record ClientMetadata
         List<JsonWebKey> jwks,
         Formats formats)
     {
+        AuthorizationEncryptedResponseEnc = authorizationEncryptedResponseEnc;
         ClientName = clientName;
         ClientUri = clientUri;
         Contacts = contacts;

--- a/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/AuthResponse/Encryption/EncryptedAuthorizationResponseTests.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/AuthResponse/Encryption/EncryptedAuthorizationResponseTests.cs
@@ -18,6 +18,7 @@ public class EncryptedAuthorizationResponseTests
         var sut = authResponse.Encrypt(
             AuthResponseEncryptionSamples.Jwk,
             nonce.AsBase64Url.ToString(),
+            Option<string>.Some("A256GCM"),
             mdocNonce);
 
         sut.Jwe.Length().Should().Be(AuthResponseEncryptionSamples.ValidMdocJwe.Length);
@@ -32,6 +33,7 @@ public class EncryptedAuthorizationResponseTests
         var sut = authResponse.Encrypt(
             AuthResponseEncryptionSamples.Jwk,
             nonce.AsBase64Url.ToString(),
+            Option<string>.Some("A256GCM"),
             Option<Nonce>.None);
 
         sut.Jwe.Length.Should().Be(AuthResponseEncryptionSamples.ValidSdJwtJwe.Length);


### PR DESCRIPTION
#### Short description of what this resolves:
- Make use of state in Encrypted Auth Response
- Use requested encoding from ClientMetadata for Encrypted Auth Response
