### PR TITLE
Decouple transaction data from PEX

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/Services/DcqlService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/Services/DcqlService.cs
@@ -5,11 +5,9 @@ using WalletFramework.Core.Credentials.Abstractions;
 using WalletFramework.Core.Functional;
 using WalletFramework.Core.Path;
 using WalletFramework.Oid4Vc.Oid4Vci.Abstractions;
-using WalletFramework.Oid4Vc.Oid4Vci.CredConfiguration.Models;
 using WalletFramework.Oid4Vc.Oid4Vci.Implementations;
 using WalletFramework.Oid4Vc.Oid4Vp.Dcql.Models;
 using WalletFramework.Oid4Vc.Oid4Vp.Models;
-using WalletFramework.Oid4Vc.Oid4Vp.PresentationExchange.Models;
 using WalletFramework.SdJwtVc.Services.SdJwtVcHolderService;
 
 namespace WalletFramework.Oid4Vc.Oid4Vp.Dcql.Services;
@@ -43,9 +41,9 @@ public class DcqlService(IAgentProvider agentProvider,
     }
 
     public AuthorizationResponse CreateAuthorizationResponse(AuthorizationRequest authorizationRequest,
-        (string Identifier, string Presentation, Format Format)[] presentationMap)
+        PresentationMap[] presentationMaps)
     {
-        var vpToken = presentationMap.ToDictionary(
+        var vpToken = presentationMaps.ToDictionary(
             presentationItem => presentationItem.Identifier,
             presentationItem => presentationItem.Presentation);
         

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/Services/IDcqlService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/Services/IDcqlService.cs
@@ -1,5 +1,4 @@
 using LanguageExt;
-using WalletFramework.Oid4Vc.Oid4Vci.CredConfiguration.Models;
 using WalletFramework.Oid4Vc.Oid4Vp.Dcql.Models;
 using WalletFramework.Oid4Vc.Oid4Vp.Models;
 
@@ -23,11 +22,11 @@ public interface IDcqlService
     ///     Creates the Parameters that are necessary to send an OpenId4VP Authorization Response.
     /// </summary>
     /// <param name="authorizationRequest"></param>
-    /// <param name="presentationMap"></param>
+    /// <param name="presentationMaps"></param>
     /// <returns>
     ///     An authorization response including the VP Token.
     /// </returns>
     AuthorizationResponse CreateAuthorizationResponse(
         AuthorizationRequest authorizationRequest,
-        (string Identifier, string Presentation, Format Format)[] presentationMap);
+        PresentationMap[] presentationMaps);
 }

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Models/PresentationMap.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Models/PresentationMap.cs
@@ -1,0 +1,5 @@
+using WalletFramework.Oid4Vc.Oid4Vci.CredConfiguration.Models;
+
+namespace WalletFramework.Oid4Vc.Oid4Vp.Models;
+
+public record PresentationMap(string Identifier, string Presentation, Format Format);

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/PresentationExchange/Services/IPexService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/PresentationExchange/Services/IPexService.cs
@@ -1,5 +1,4 @@
 using LanguageExt;
-using WalletFramework.Oid4Vc.Oid4Vci.CredConfiguration.Models;
 using WalletFramework.Oid4Vc.Oid4Vp.Models;
 using WalletFramework.Oid4Vc.Oid4Vp.PresentationExchange.Models;
 
@@ -26,11 +25,11 @@ public interface IPexService
     ///     Creates the Parameters that are necessary to send an OpenId4VP Authorization Response.
     /// </summary>
     /// <param name="authorizationRequest"></param>
-    /// <param name="presentationMap"></param>
+    /// <param name="presentationMaps"></param>
     /// <returns>
     ///     A task representing the asynchronous operation. The task result contains the Presentation Submission and the VP Token.
     /// </returns>
     Task<AuthorizationResponse> CreateAuthorizationResponseAsync(
         AuthorizationRequest authorizationRequest,
-        (string Identifier, string Presentation, Format Format)[] presentationMap);
+        PresentationMap[] presentationMaps);
 }

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/PresentationExchange/Services/PexService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/PresentationExchange/Services/PexService.cs
@@ -50,20 +50,20 @@ public class PexService(
     /// <inheritdoc />
     public async Task<AuthorizationResponse> CreateAuthorizationResponseAsync(
         AuthorizationRequest authorizationRequest,
-        (string Identifier, string Presentation, Oid4Vci.CredConfiguration.Models.Format Format)[] presentationMap)
+        PresentationMap[] presentationMaps)
     {
         var descriptorMaps = new List<DescriptorMap>();
         var vpToken = new List<string>();
             
-        for (var index = 0; index < presentationMap.Length; index++)
+        for (var index = 0; index < presentationMaps.Length; index++)
         {
-            vpToken.Add(presentationMap[index].Presentation);
+            vpToken.Add(presentationMaps[index].Presentation);
 
             var descriptorMap = new DescriptorMap
             {
-                Format = presentationMap[index].Format.ToString(),
-                Path = presentationMap.Length > 1 ? "$[" + index + "]" : "$",
-                Id = presentationMap[index].Identifier,
+                Format = presentationMaps[index].Format.ToString(),
+                Path = presentationMaps.Length > 1 ? "$[" + index + "]" : "$",
+                Id = presentationMaps[index].Identifier,
                 PathNested = null
             };
             descriptorMaps.Add(descriptorMap);

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Services/IOid4VpHaipClient.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Services/IOid4VpHaipClient.cs
@@ -1,5 +1,4 @@
 using WalletFramework.Oid4Vc.Oid4Vp.Models;
-using Format = WalletFramework.Oid4Vc.Oid4Vci.CredConfiguration.Models.Format;
 
 namespace WalletFramework.Oid4Vc.Oid4Vp.Services;
 
@@ -12,9 +11,9 @@ public interface IOid4VpHaipClient
     ///     Creates the Parameters that are necessary to send an OpenId4VP Authorization Response.
     /// </summary>
     /// <param name="authorizationRequest"></param>
-    /// <param name="presentationMap"></param>
+    /// <param name="presentationMaps"></param>
     /// <returns>
     ///     A task representing the asynchronous operation. The task result contains the Presentation Submission and the VP Token.
     /// </returns>
-    Task<AuthorizationResponse> CreateAuthorizationResponseAsync(AuthorizationRequest authorizationRequest, (string Identifier, string Presentation, Format Format)[] presentationMap);
+    Task<AuthorizationResponse> CreateAuthorizationResponseAsync(AuthorizationRequest authorizationRequest, PresentationMap[] presentationMaps);
 }

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Services/Oid4VpHaipClient.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Services/Oid4VpHaipClient.cs
@@ -1,9 +1,6 @@
 using WalletFramework.Oid4Vc.Oid4Vp.Dcql.Services;
 using WalletFramework.Oid4Vc.Oid4Vp.Models;
-using WalletFramework.Oid4Vc.Oid4Vp.PresentationExchange.Models;
 using WalletFramework.Oid4Vc.Oid4Vp.PresentationExchange.Services;
-using static Newtonsoft.Json.JsonConvert;
-using Format = WalletFramework.Oid4Vc.Oid4Vci.CredConfiguration.Models.Format;
 
 namespace WalletFramework.Oid4Vc.Oid4Vp.Services;
 
@@ -15,10 +12,10 @@ internal class Oid4VpHaipClient(
     /// <inheritdoc />
     public Task<AuthorizationResponse> CreateAuthorizationResponseAsync(
         AuthorizationRequest authorizationRequest,
-        (string Identifier, string Presentation, Format Format)[] presentationMap)
+        PresentationMap[] presentationMaps)
     {
         return authorizationRequest.Requirements.Match(
-            dcqlQuery => Task.FromResult(dcqlService.CreateAuthorizationResponse(authorizationRequest, presentationMap)),
-            presentationDefinition => pexService.CreateAuthorizationResponseAsync(authorizationRequest, presentationMap));
+            dcqlQuery => Task.FromResult(dcqlService.CreateAuthorizationResponse(authorizationRequest, presentationMaps)),
+            presentationDefinition => pexService.CreateAuthorizationResponseAsync(authorizationRequest, presentationMaps));
     }
 }

--- a/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/PresentationExchange/Services/PexServiceTests.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/PresentationExchange/Services/PexServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Data.Common;
 using FluentAssertions;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Storage;
@@ -51,20 +50,10 @@ public class PexServiceTests
         var authRequest = JsonConvert.DeserializeObject<AuthorizationRequest>(PexTestsDataProvider.GetJsonForTestCase())!;
         var presentationDefinition = authRequest.PresentationDefinition!;
 
-        var presentationMap = new (string Identifier, string Presentation, Format Format)[]
+        var presentationMap = new PresentationMap[]
         {
-            new()
-            {
-                Identifier = presentationDefinition.InputDescriptors[0].Id,
-                Presentation = Guid.NewGuid().ToString(),
-                Format = FormatFun.CreateSdJwtFormat()
-            },
-            new()
-            {
-                Identifier = presentationDefinition.InputDescriptors[1].Id,
-                Presentation = Guid.NewGuid().ToString(),
-                Format = FormatFun.CreateSdJwtFormat()
-            }
+            new(presentationDefinition.InputDescriptors[0].Id,Guid.NewGuid().ToString(),FormatFun.CreateSdJwtFormat()),
+            new(presentationDefinition.InputDescriptors[1].Id,Guid.NewGuid().ToString(),FormatFun.CreateSdJwtFormat())
         };
             
         var authResponse = await CreatePexService().CreateAuthorizationResponseAsync(authRequest, presentationMap);


### PR DESCRIPTION
#### Short description of what this resolves:
This PR decouples transaction data from PEX as this led to exceptions when using DCQL queries.
A PresentationMap type is also introduced, which replaces a frequently used Tuple.

#### Changes proposed in this pull request:

-
-
-

**Fixes**: #
