### PR TITLE
prevent deletion of last batch credential

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Services/Oid4VpClientService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Services/Oid4VpClientService.cs
@@ -281,10 +281,25 @@ public class Oid4VpClientService : IOid4VpClientService
             switch (credential.Credential)
             {
                 case SdJwtRecord { OneTimeUse: true } sdJwtRecord:
-                    await _sdJwtVcHolderService.DeleteAsync(context, sdJwtRecord.GetId());
+                    var credentialSetSdJwtRecords = await _sdJwtVcHolderService.ListAsync(context, sdJwtRecord.GetCredentialSetId());
+                    await credentialSetSdJwtRecords.Match(
+                        async sdJwtRecords =>
+                        {
+                            if (sdJwtRecords.Count() > 1)
+                                await _sdJwtVcHolderService.DeleteAsync(context, sdJwtRecord.GetId());
+
+                        },
+                        () => Task.CompletedTask);
                     break;
                 case MdocRecord { OneTimeUse: true } mDocRecord:
-                    await _mDocStorage.Delete(mDocRecord);
+                    var credentialSetMdocRecords = await _mDocStorage.List(mDocRecord.GetCredentialSetId());
+                    await credentialSetMdocRecords.Match(
+                        async mDocRecords =>
+                        {
+                            if (mDocRecords.Count() > 1)
+                                await _mDocStorage.Delete(mDocRecord);
+                        },
+                        () => Task.CompletedTask);
                     break;
             }
         }

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Services/Oid4VpClientService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Services/Oid4VpClientService.cs
@@ -287,7 +287,6 @@ public class Oid4VpClientService : IOid4VpClientService
                         {
                             if (sdJwtRecords.Count() > 1)
                                 await _sdJwtVcHolderService.DeleteAsync(context, sdJwtRecord.GetId());
-
                         },
                         () => Task.CompletedTask);
                     break;


### PR DESCRIPTION
#### Short description of what this resolves:
This PR prevents the deletion of the last batch credential instance, because there is currently no way implemented to receive a new batch of credential instances.

#### Changes proposed in this pull request:

-
-
-

**Fixes**: #
