### PR TITLE
prevent null value serialization in JwtSigner

### DIFF
--- a/src/WalletFramework.SdJwtVc/Services/SdJwtVcHolderService/SdJwtSigner.cs
+++ b/src/WalletFramework.SdJwtVc/Services/SdJwtVcHolderService/SdJwtSigner.cs
@@ -63,8 +63,13 @@ public class SdJwtSigner(IKeyStore keyStore) : ISdJwtSigner
     
     public async Task<string> CreateSignedJwt(object header, object payload, KeyId keyId)
     {
-        var encodedHeader = Base64UrlEncoder.Encode(JsonConvert.SerializeObject(header));
-        var encodedPayload = Base64UrlEncoder.Encode(JsonConvert.SerializeObject(payload));
+        var serializerSettings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore
+        };
+        
+        var encodedHeader = Base64UrlEncoder.Encode(JsonConvert.SerializeObject(header, serializerSettings));
+        var encodedPayload = Base64UrlEncoder.Encode(JsonConvert.SerializeObject(payload, serializerSettings));
 
         var dataToSign = encodedHeader + "." + encodedPayload;
         var signature = await keyStore.Sign(keyId, Encoding.UTF8.GetBytes(dataToSign));


### PR DESCRIPTION
#### Short description of what this resolves:
- This PR prevents the serialization of null values in the Header and Payload of JWT that we sign using the JWTSigner
