### PR TITLE
Fix aud claim value in KB-JWT

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Services/Oid4VpClientService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Services/Oid4VpClientService.cs
@@ -197,7 +197,7 @@ public class Oid4VpClientService : IOid4VpClientService
                         txDataBase64UrlStringsOption,
                         txDataHashesAsHexOption,
                         txDataHashesAlgOption,
-                        authorizationRequest.ClientId,
+                        $"{authorizationRequest.ClientIdScheme}:{authorizationRequest.ClientId}",
                         authorizationRequest.Nonce);
 
                     presentedCredential = sdJwt;


### PR DESCRIPTION
#### Short description of what this resolves:
- Fix the syntax of the value used for the aud claim in the KB-JWT (use <client_id_scheme>:<client_id> instead of <client_id>)
