### PR TITLE
enforce doctype match for mdoc pex

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/PresentationExchange/Services/PexService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/PresentationExchange/Services/PexService.cs
@@ -170,7 +170,8 @@ public class PexService(
         var filteredMdocRecords = mdocRecords.OnSome(records => records
             .Where(record =>
             {
-                return record.Mdoc.IssuerSigned.IssuerAuth.ProtectedHeaders.Value.TryGetValue(new CoseLabel(1), out var alg)
+                return record.DocType == inputDescriptor.Id
+                       && record.Mdoc.IssuerSigned.IssuerAuth.ProtectedHeaders.Value.TryGetValue(new CoseLabel(1), out var alg)
                        && supportedFormatSigningAlgorithms.Match(
                            formats => formats.MDocFormat?.Alg?.Contains(alg.ToString()) ?? true,
                            () => inputDescriptor.Formats?.MDocFormat?.Alg?.Contains(alg.ToString()) ?? true)


### PR DESCRIPTION
#### Short description of what this resolves:
This PR fixes an issue where a VP with PEX for mDoc did not compare the requested docType against the docType of the credentials.


#### Changes proposed in this pull request:

-
-
-

**Fixes**: #
