### PR TITLE
fix malformed query strings

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vci/Implementations/Oid4VciClientService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vci/Implementations/Oid4VciClientService.cs
@@ -149,7 +149,7 @@ public class Oid4VciClientService : IOid4VciClientService
         var authServerMetadata = await FetchAuthorizationServerMetadataAsync(issuerMetadata, offer.CredentialOffer);
         
         var authorizationRequestUri = authServerMetadata.PushedAuthorizationRequestEndpoint.IsNullOrEmpty()
-            ? new Uri(authServerMetadata.AuthorizationEndpoint + "?" + vciAuthorizationRequest.ToQueryString())
+            ? new Uri(authServerMetadata.AuthorizationEndpoint + vciAuthorizationRequest.ToQueryString())
             : await GetRequestUriUsingPushedAuthorizationRequest(authServerMetadata, vciAuthorizationRequest);
         
         var authorizationData = new AuthorizationData(
@@ -211,7 +211,7 @@ public class Oid4VciClientService : IOid4VciClientService
                     null);
                 
                 var authorizationRequestUri = authServerMetadata.PushedAuthorizationRequestEndpoint.IsNullOrEmpty()
-                    ? new Uri(authServerMetadata.AuthorizationEndpoint + "?" + vciAuthorizationRequest.ToQueryString())
+                    ? new Uri(authServerMetadata.AuthorizationEndpoint + vciAuthorizationRequest.ToQueryString())
                     : await GetRequestUriUsingPushedAuthorizationRequest(authServerMetadata, vciAuthorizationRequest);
                 
                 //TODO: Select multiple configurationIds


### PR DESCRIPTION
#### Short description of what this resolves:
This PR fixes malformed query strings and ensures that they contain only one "?"


#### Changes proposed in this pull request:

-
-
-

**Fixes**: #
