### PR TITLE
also use the id from the input descriptor to extract the docType

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/PresentationExchange/Models/InputDescriptor.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/PresentationExchange/Models/InputDescriptor.cs
@@ -156,9 +156,17 @@ public static class InputDescriptorFun
                 .Select<Field, OneOf<Vct, DocType>>(field =>
                 {
                     return DocType.ValidDoctype(field.Filter!.Const!).UnwrapOrThrow();
-                });
+                })
+                .ToList();
 
-            result = types?.ToList() ?? [];
+            if (types == null || !types.Any())
+            {
+                types = DocType.ValidDoctype(inputDescriptor.Id).Match(
+                    docType => [docType],
+                    _ => new List<OneOf<Vct, DocType>>());
+            }
+
+            result = types;
         }
 
         return result.Count != 0 ? result[0] : Option<OneOf<Vct, DocType>>.None;


### PR DESCRIPTION
#### Short description of what this resolves:
- Also use the id of the InputDescriptor to extract the requested docType of a presentation request.
