### PR TITLE
Fix the DCQL missing credential filtering

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/CredentialQueries/CredentialQuery.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/CredentialQueries/CredentialQuery.cs
@@ -138,7 +138,7 @@ public static class CredentialQueryFun
                     : Option<OneOf<Vct, DocType>>.None;
             case Constants.MdocFormat:
                 return credentialQuery.Meta?.Doctype?.Any() == true
-                    ? Option<OneOf<Vct, DocType>>.Some(Vct.ValidVct(credentialQuery.Meta!.Doctype).UnwrapOrThrow())
+                    ? Option<OneOf<Vct, DocType>>.Some(DocType.ValidDoctype(credentialQuery.Meta!.Doctype).UnwrapOrThrow())
                     : Option<OneOf<Vct, DocType>>.None;
             default:
                 return Option<OneOf<Vct, DocType>>.None;

--- a/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/Dcql/CredentialSets/CredentialSetTests.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/Dcql/CredentialSets/CredentialSetTests.cs
@@ -64,6 +64,29 @@ public class CredentialSetTests
         candidatesList.Count.Should().Be(2, "should have a candidate for each credential query in the set");
         candidateSet.IsRequired.Should().BeTrue();
     }
+    
+    [Fact]
+    public void Candidate_Query_Result_Can_Be_Built_Correctly_From_Dcql_With_One_Credential_Set_And_Filter_Missing_Credentials_That_Are_Only_Alternatives()
+    {
+        // Arrange
+        var query = DcqlSamples.GetDcqlQueryWithOneCredentialSetAndMultipleSingleOptions;
+        var idCard = SdJwtSamples.GetIdCardCredential();
+        var credentials = new List<ICredential> { idCard };
+
+        // Act
+        var result = query.ProcessWith(credentials);
+
+        // Assert
+        result.MissingCredentials.IsNone.Should().BeTrue();
+        result.Candidates.IsSome.Should().BeTrue();
+        var sets = result.Candidates.IfNone([]);
+        var setsList = sets.ToList();
+        setsList.Count.Should().Be(1, "only one set should be satisfied by the provided credentials");
+        var candidateSet = setsList[0];
+        var candidatesList = candidateSet.Candidates.ToList();
+        candidatesList.Count.Should().Be(1, "should have a candidate for each credential query in the set");
+        candidateSet.IsRequired.Should().BeTrue();
+    }
 
     [Fact]
     public void Candidate_Set_Wont_Be_Built_When_A_Credential_is_Missing()

--- a/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/Dcql/Samples/DcqlSamples.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/Dcql/Samples/DcqlSamples.cs
@@ -106,6 +106,43 @@ public static class DcqlSamples
     }
   ]
 }";
+    
+    public const string DcqlQueryWithOneCredentialSetAndMultipleSingleOptionsJson = @"{
+  ""credentials"": [
+    {
+      ""id"": ""idcard"",
+      ""format"": ""dc+sd-jwt"",
+      ""meta"": {
+        ""vct_values"": [""ID-Card""]
+      },
+      ""claims"": [
+        {""path"": [""first_name""]},
+        {""path"": [""last_name""]},
+        {""path"": [""address"", ""street_address""]}
+      ]
+    },
+    {
+      ""id"": ""idcard2"",
+      ""format"": ""dc+sd-jwt"",
+      ""meta"": {
+        ""vct_values"": [""ID-Card-2""]
+      },
+      ""claims"": [
+        {""path"": [""first_name""]},
+        {""path"": [""last_name""]},
+        {""path"": [""address"", ""street_address""]}
+      ]
+    }
+  ],
+  ""credential_sets"": [
+    {
+      ""options"": [
+        [ ""idcard""],
+        [ ""idcard2""]
+      ]
+    }
+  ]
+}";
 
     public const string IdCardAndIdCard2NationalitiesSecondIndexQueryJson = @"{
             ""credentials"": [
@@ -194,7 +231,10 @@ public static class DcqlSamples
 
     public static DcqlQuery GetDcqlQueryWithNoClaims =>
         JsonConvert.DeserializeObject<DcqlQuery>(QueryStrWithNoClaims)!;
-
+    
+    public static DcqlQuery GetDcqlQueryWithOneCredentialSetAndMultipleSingleOptions =>
+        JsonConvert.DeserializeObject<DcqlQuery>(DcqlQueryWithOneCredentialSetAndMultipleSingleOptionsJson)!;
+    
     public static string GetDcqlQueryAsJsonStr() => GetJsonForTestCase("DcqlQuerySample");
 
     public static DcqlQuery GetIdCardAndIdCard2NationalitiesSecondIndexQuery() =>


### PR DESCRIPTION
#### Short description of what this resolves:
This PR tracks credentials that are only alternatives in the DCQL queries and therefore stops handling them as missing credentials as they are not relevant to answer the proof.