### PR TITLE
MDoc adjustments in engegment reagarding ISO 18013-5

### DIFF
--- a/src/WalletFramework.MdocLib/Ble/BleUuids/BleUuid.cs
+++ b/src/WalletFramework.MdocLib/Ble/BleUuids/BleUuid.cs
@@ -29,11 +29,12 @@ public readonly struct BleUuid
     {
         try
         {
-            return FromString(cbor.AsString());
+            var uuid = new Guid(cbor.GetByteString());
+            return new BleUuid(uuid.ToString());
         }
         catch (Exception e)
         {
-            return new CborIsNotATextStringError(name, e);
+            return new CborIsNotAByteStringError(name, e);
         }
     }
 }    

--- a/src/WalletFramework.MdocLib/Reader/EngagementUri.cs
+++ b/src/WalletFramework.MdocLib/Reader/EngagementUri.cs
@@ -8,7 +8,7 @@ namespace WalletFramework.MdocLib.Reader;
 
 public record EngagementUri(Base64UrlString Value, CBORObject AsCbor)
 {
-    public const string Scheme = "mdoc://";
+    public const string Scheme = "mdoc:";
     
     public static Validation<EngagementUri> FromString(string input)
     {


### PR DESCRIPTION
#### Short description of what this resolves:

While testing two postions where found not follwoing ISO/IEC 18013-5:2021 regarding mdoc

#### Changes proposed in this pull request:

- Change FromCbor in BleUuid parsing a ByteString instead of String as written in the standard. (See chapter 8.2.2.3)
- Sheme for Engagement Uri is `mdoc:` not `mdoc://` (See chapter 8.2.2.3)

**Fixes**: #352