### PR TITLE
Add csc transaction data types and unit tests

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/TransactionDatas/TransactionDataType.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/TransactionDatas/TransactionDataType.cs
@@ -29,7 +29,11 @@ public static class SupportedTransactionDataTypeConstants
 
     public const string Qes = "qes_authorization";
     
+    public const string CscQes = "https://cloudsignatureconsortium.org/2025/qes";
+    
     public const string QCertCreation = "qcert_creation_acceptance";
+    
+    public const string CscQCertCreation = "https://cloudsignatureconsortium.org/2025/qc-request";
 }
 
 public readonly struct TransactionDataType
@@ -55,7 +59,9 @@ public readonly struct TransactionDataType
         {
             SupportedTransactionDataTypeConstants.Payment => new TransactionDataType(TransactionDataTypeValue.Payment),
             SupportedTransactionDataTypeConstants.Qes => new TransactionDataType(TransactionDataTypeValue.Qes),
+            SupportedTransactionDataTypeConstants.CscQes => new TransactionDataType(TransactionDataTypeValue.Qes),
             SupportedTransactionDataTypeConstants.QCertCreation => new TransactionDataType(TransactionDataTypeValue.QCertCreation),
+            SupportedTransactionDataTypeConstants.CscQCertCreation => new TransactionDataType(TransactionDataTypeValue.QCertCreation),
             _ => throw new ArgumentOutOfRangeException()
         };
     }

--- a/test/WalletFramework.Oid4Vc.Tests/QCertCreation/QCertCreationTests.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/QCertCreation/QCertCreationTests.cs
@@ -6,10 +6,19 @@ namespace WalletFramework.Oid4Vc.Tests.QCertCreation;
 
 public class QCertCreationTests
 {
-    [Fact]
-    public void Can_Parse_QCertCreation_Transaction_Data()
+    [Theory]
+    [InlineData(nameof(QCertCreationTransactionDataSamples.QCertJsonSample))]
+    [InlineData(nameof(QCertCreationTransactionDataSamples.CscQCertJsonSample))]
+    public void Can_Parse_QCertCreation_Transaction_Data(string sampleName)
     {
-        var sample = QCertCreationTransactionDataSamples.GetBase64UrlStringSample();
+        var jsonSample = sampleName switch
+        {
+            nameof(QCertCreationTransactionDataSamples.QCertJsonSample) => QCertCreationTransactionDataSamples.QCertJsonSample,
+            nameof(QCertCreationTransactionDataSamples.CscQCertJsonSample) => QCertCreationTransactionDataSamples.CscQCertJsonSample,
+            _ => throw new ArgumentException($"Unknown sample name: {sampleName}")
+        };
+
+        var sample = QCertCreationTransactionDataSamples.ToBase64UrlString(jsonSample);
 
         var sut = TransactionData.FromBase64Url(sample);
         sut.Match(
@@ -19,7 +28,7 @@ public class QCertCreationTests
             },
             errors =>
             {
-                Assert.Fail("QCertCreationtTransactionData Validation failed");
+                Assert.Fail($"QCertCreationTransactionData Validation failed for sample: {sampleName}");
             });
     }
 }

--- a/test/WalletFramework.Oid4Vc.Tests/QCertCreation/Samples/QCertTransactionDataSamples.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/QCertCreation/Samples/QCertTransactionDataSamples.cs
@@ -7,7 +7,7 @@ namespace WalletFramework.Oid4Vc.Tests.QCertCreation.Samples;
 
 public static class QCertCreationTransactionDataSamples
 {
-    public static string JsonSample => new JObject
+    public static string QCertJsonSample => new JObject
     {
         ["type"] = "qcert_creation_acceptance",
         ["QC_terms_conditions_uri"] = "https://example.com/tos",
@@ -20,10 +20,22 @@ public static class QCertCreationTransactionDataSamples
         },
     }.ToString();
 
-    public static Base64UrlString GetBase64UrlStringSample()
+    public static string CscQCertJsonSample => new JObject
     {
-        var str = JsonSample;
-        var encoded = Base64UrlEncoder.Encode(str);
+        ["type"] = "https://cloudsignatureconsortium.org/2025/qc-request",
+        ["credential_ids"] = new JArray
+        {
+            "credential-id-1"
+        },
+        ["QC_terms_conditions_uri"] = "https://qtsp.example.com/policies/terms_and_conditions.pdf",
+        ["QC_hash"] = "ohxKcClPp/J1dI1iv5x519BpjduGZC794x4ABFeb+Ds=",
+        ["QC_hashAlgorithmOID"] = "2.16.840.1.101.3.4.2.1",
+        ["transaction_data_hashes_alg"] = "sha-256"
+    }.ToString();
+
+    public static Base64UrlString ToBase64UrlString(string qCertJsonString)
+    {
+        var encoded = Base64UrlEncoder.Encode(qCertJsonString);
         return Base64UrlString.FromString(encoded).UnwrapOrThrow();
     }
 }

--- a/test/WalletFramework.Oid4Vc.Tests/Signatures/Samples/SignatureTransactionDataSamples.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/Signatures/Samples/SignatureTransactionDataSamples.cs
@@ -1,0 +1,37 @@
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json.Linq;
+using WalletFramework.Core.Base64Url;
+using WalletFramework.Core.Functional;
+
+namespace WalletFramework.Oid4Vc.Tests.Signatures.Samples;
+
+public static class SignatureTransactionDataSamples
+{
+    public static string CscSignatureJsonSample => new JObject
+    {
+        ["type"] = "https://cloudsignatureconsortium.org/2025/qes",
+        ["credential_ids"] = new JArray
+        {
+            "my_credential"
+        },
+        ["numSignatures"] = 1,
+        ["signatureQualifier"] = "eu_eidas_qes",
+        ["documentDigests"] = new JArray
+        {
+            new JObject
+            {
+                ["label"] = "Example Contract",
+                ["hashType"] = "sodr",
+                ["hash"] = "HZQzZmMAIWekfGH0/ZKW1nsdt0xg3H6bZYztgsMTLw0="
+            }
+        },
+        ["processID"] = "eOZ6UwXyeFLK98Do51x33fmuv4OqAz5Zc4lshKNtEgQ=",
+        ["transaction_data_hashes_alg"] = "sha-256"
+    }.ToString();
+
+    public static Base64UrlString ToBase64UrlString()
+    {
+        var encoded = Base64UrlEncoder.Encode(CscSignatureJsonSample);
+        return Base64UrlString.FromString(encoded).UnwrapOrThrow();
+    }
+}

--- a/test/WalletFramework.Oid4Vc.Tests/Signatures/SignatureTests.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/Signatures/SignatureTests.cs
@@ -1,0 +1,25 @@
+using WalletFramework.Core.Functional;
+using WalletFramework.Oid4Vc.Oid4Vp.TransactionDatas;
+using WalletFramework.Oid4Vc.Tests.Signatures.Samples;
+
+namespace WalletFramework.Oid4Vc.Tests.Signatures;
+
+public class SignatureTests
+{
+    [Fact]
+    public void Can_Parse_QCertCreation_Transaction_Data()
+    {
+        var sample = SignatureTransactionDataSamples.ToBase64UrlString();
+
+        var sut = TransactionData.FromBase64Url(sample);
+        sut.Match(
+            _ =>
+            {
+                // TODO: Check properties
+            },
+            errors =>
+            {
+                Assert.Fail("QCertCreationTransactionData Validation failed");
+            });
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:
- Add transaction data _qes_ and _qcert acceptance_ types for csc spec
- Add appropriate unit tests
