### PR TITLE
Add href property of CSC transaction data

### DIFF
--- a/src/WalletFramework.Oid4Vc/Qes/Authorization/DocumentDigest.cs
+++ b/src/WalletFramework.Oid4Vc/Qes/Authorization/DocumentDigest.cs
@@ -19,10 +19,16 @@ public record DocumentDigest(
         var uriValidation = 
             from documentLocationUri in jObject.GetByKey("documentLocation_uri")
             select new Uri(documentLocationUri.ToString());
+        
+        var hrefValidation = 
+            from documentLocationUri in jObject.GetByKey("href")
+            select new Uri(documentLocationUri.ToString());
 
         return
             from label in labelValidation
-            let uriOption = uriValidation.ToOption()
+            let uriOption = hrefValidation.ToOption().Match(
+                hrefUri => hrefUri,
+                () => uriValidation.ToOption())
             select new DocumentDigest(label, uriOption);
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
The CSC transaction data uses a _href_ property instead of the _documentLocation_uri_
