### PR TITLE
feature: Support Legacy Protocol 'openid4vp' for DC-API

### DIFF
--- a/src/WalletFramework.Oid4Vc/Oid4Vp/DcApi/DcApiConstants.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/DcApi/DcApiConstants.cs
@@ -5,4 +5,6 @@ public static class DcApiConstants
     public const string SignedProtocol = "openid4vp-v1-signed";
 
     public const string UnsignedProtocol = "openid4vp-v1-unsigned";
+    
+    public const string LegacyProtocol = "openid4vp";
 }

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/DcApi/Models/DcApiRequestItem.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/DcApi/Models/DcApiRequestItem.cs
@@ -83,6 +83,7 @@ public record DcApiRequestItem
         switch (protocol)
         {
             case DcApiConstants.UnsignedProtocol:
+            case DcApiConstants.LegacyProtocol:
                 var r = AuthorizationRequest.CreateAuthorizationRequest(jObject);
                 return LiftRequest(r);
             case DcApiConstants.SignedProtocol:


### PR DESCRIPTION
#### Short description of what this resolves:

For backwards compability reasons i added 'openid4vp' to the allowed protocols.

#### Changes proposed in this pull request:

- 'openid4vp' will be handled the same 'opendi4vp-v1-unsigned'
-
-
