### PR TITLE
DCQL - Make the meta property mandatory

### DIFF
--- a/src/WalletFramework.Core/Functional/Errors/ObjectRequirementsAreNotMetError.cs
+++ b/src/WalletFramework.Core/Functional/Errors/ObjectRequirementsAreNotMetError.cs
@@ -1,0 +1,3 @@
+namespace WalletFramework.Core.Functional.Errors;
+
+public record ObjectRequirementsAreNotMetError<T>(string errorMessage) : Error($"Requirements of Type `{typeof(T).Name}` were not met: {errorMessage}");

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/CredentialQueries/CredentialQuery.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/CredentialQueries/CredentialQuery.cs
@@ -58,8 +58,15 @@ public class CredentialQuery
     {
         var id = json.GetByKey(IdJsonKey)
             .OnSuccess(token => token.ToJValue())
-            .OnSuccess(value => CredentialQueryId.Create(value.Value?.ToString() ?? string.Empty))
-            .ToOption();
+            .OnSuccess(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value.Value?.ToString()))
+                {
+                    return new StringIsNullOrWhitespaceError<CredentialQueryId>();
+                }
+
+                return CredentialQueryId.Create(value.Value.ToString());
+            });
 
         var format = json.GetByKey(FormatJsonKey)
             .OnSuccess(token => token.ToJValue())
@@ -99,13 +106,13 @@ public class CredentialQuery
     }
 
     private static CredentialQuery Create(
-        Option<CredentialQueryId> id,
+        CredentialQueryId id,
         string format,
         CredentialMetaQuery meta,
         Option<IEnumerable<ClaimQuery>> claims,
         Option<IEnumerable<ClaimSet>> claimSets) => new()
     {
-        Id = id.ToNullable(),
+        Id = id,
         Format = format,
         Meta = meta,
         Claims = claims.ToNullable()?.ToArray(),

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/Models/CredentialMetaQuery.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/Models/CredentialMetaQuery.cs
@@ -12,18 +12,19 @@ namespace WalletFramework.Oid4Vc.Oid4Vp.Dcql.Models;
 /// <summary>
 /// The credential query meta.
 /// </summary>
+
 public class CredentialMetaQuery
 {
     /// <summary>
     /// Specifies allowed values for the type of the requested Verifiable credential.
     /// </summary>
-    [JsonProperty("vct_values")]
+    [JsonProperty(VctValuesJsonKey)]
     public IEnumerable<string>? Vcts { get; set; }
     
     /// <summary>
     /// Specifies an allowed value for the doctype of the requested Verifiable credential.
     /// </summary>
-    [JsonProperty("doctype_value")]
+    [JsonProperty(DoctypeValueJsonKey)]
     public string? Doctype { get; set; }
     
     public static Validation<CredentialMetaQuery> FromJObject(JObject json)
@@ -54,6 +55,12 @@ public class CredentialMetaQuery
                 return ValidationFun.Valid(value.Value.ToString());
             })
             .ToOption();
+
+        if (!(vcts.IsSome ^ doctype.IsSome))
+        {
+            return new ObjectRequirementsAreNotMetError<CredentialMetaQuery>(
+                "In the CredentialMetaQuery the 'vct_values' and 'doctype_value' must be mutually exclusive.");
+        }
         
         return ValidationFun.Valid(Create)
             .Apply(vcts)

--- a/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/Models/CredentialMetaQueryJsonConverter.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vp/Dcql/Models/CredentialMetaQueryJsonConverter.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using WalletFramework.Core.Functional;
+
+namespace WalletFramework.Oid4Vc.Oid4Vp.Dcql.Models;
+
+public class CredentialMetaQueryJsonConverter : JsonConverter<CredentialMetaQuery>
+{
+    public override CredentialMetaQuery ReadJson(JsonReader reader, Type objectType, CredentialMetaQuery? existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        var jObject = JObject.Load(reader);
+        
+        return CredentialMetaQuery.FromJObject(jObject).Match(
+            metadataQuery => metadataQuery,
+            errors => throw new JsonSerializationException(
+                $"Failed to deserialize CredentialMetaQuery: {string.Join(", ", errors.Select(e => e.Message))}")
+        );
+    }
+
+    public override void WriteJson(JsonWriter writer, CredentialMetaQuery? value, JsonSerializer serializer)
+    {
+        var jObject = new JObject();
+        
+        if (value!.Vcts != null)
+        {
+            jObject[CredentialMetaFun.VctValuesJsonKey] = JToken.FromObject(value.Vcts, serializer);
+        }
+        
+        if (value!.Doctype != null)
+        {
+            jObject[CredentialMetaFun.DoctypeValueJsonKey] = JToken.FromObject(value.Doctype, serializer);
+        }
+        
+        jObject.WriteTo(writer);
+    }
+}

--- a/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/DcApi/DcApiRequestBatchTests.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/DcApi/DcApiRequestBatchTests.cs
@@ -36,7 +36,7 @@ public class DcApiRequestBatchTests
                 var credentialQuery = dcApiRequest.DcqlQuery.CredentialQueries[0];
                 credentialQuery.Id.AsString().Should().Be("cred1");
                 credentialQuery.Format.Should().Be("mso_mdoc");
-                credentialQuery.Meta!.Doctype.Should().Be("org.iso.18013.5.1.mDL");
+                credentialQuery.Meta.Doctype.Should().Be("org.iso.18013.5.1.mDL");
                 credentialQuery.Claims.Should().HaveCount(2);
                 
                 var firstClaim = credentialQuery.Claims![0];
@@ -77,7 +77,7 @@ public class DcApiRequestBatchTests
                 var credentialQuery = dcApiRequest.DcqlQuery.CredentialQueries[0];
                 credentialQuery.Id.AsString().Should().Be("cred1");
                 credentialQuery.Format.Should().Be("mso_mdoc");
-                credentialQuery.Meta!.Doctype.Should().Be("org.iso.18013.5.1.mDL");
+                credentialQuery.Meta.Doctype.Should().Be("org.iso.18013.5.1.mDL");
                 credentialQuery.Claims.Should().HaveCount(2);
                 
                 var firstClaim = credentialQuery.Claims![0];

--- a/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/Dcql/CredentialMetaQueryJsonConverterTests.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/Dcql/CredentialMetaQueryJsonConverterTests.cs
@@ -1,0 +1,78 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using WalletFramework.Oid4Vc.Oid4Vp.Dcql.Models;
+
+namespace WalletFramework.Oid4Vc.Tests.Oid4Vp.Dcql;
+
+public class CredentialMetaQueryJsonConverterTests
+{
+    private static readonly JsonSerializerSettings Settings = new()
+    {
+        Converters =
+        {
+            new CredentialMetaQueryJsonConverter()
+        }
+    };
+    
+    [Fact]
+    public void CanSerializeCredentialMetaQuery()
+    {
+        // Arrange
+        var credentialMetaQuery = new CredentialMetaQuery()
+        {
+            Doctype = "DocumentType1"
+        };
+        
+        // Act
+        var json = JsonConvert.SerializeObject(credentialMetaQuery, Settings);
+        
+        // Assert
+        Assert.NotNull(json);
+    }
+
+    [Fact]
+    public void CanDeserializeCredentialMetaQuery()
+    {
+        //Arrange
+        var jsonString = new JObject()
+        {
+            ["vct_values"] = new JArray(){"VerifiableCredentialType1", "VerifiableCredentialType2"}
+        }.ToString();
+        
+        //Act
+        var credentialMetaQuery = JsonConvert.DeserializeObject<CredentialMetaQuery>(jsonString, Settings);
+        
+        //Assert
+        Assert.Equal(["VerifiableCredentialType1", "VerifiableCredentialType2"], credentialMetaQuery!.Vcts);
+    }
+    
+    [Fact]
+    public void ThrowsOnInvalidCredentialMetaQuery_VctValuesAndDoctypeValueIsNotMutuallyExclusive()
+    {
+        // Arrange
+        var invalidJson = new JObject()
+        {
+            ["vct_values"] = new JArray(){"VerifiableCredentialType1", "VerifiableCredentialType2"},
+            ["doctype_value"] = "DocumentType1"
+        };
+        
+        // Act & Assert
+        Assert.Throws<JsonSerializationException>(() =>
+            JsonConvert.DeserializeObject<CredentialMetaQuery>(invalidJson.ToString(), Settings));
+    }
+
+    [Fact]
+    public void ThrowsOnInvalidCredentialMetaQuery()
+    {
+        // Arrange
+        var invalidJson = new JObject()
+        {
+            ["some"] = new JArray(){1, 2},
+            ["another"] = 1
+        };
+        
+        // Act & Assert
+        Assert.Throws<JsonSerializationException>(() =>
+            JsonConvert.DeserializeObject<CredentialMetaQuery>(invalidJson.ToString(), Settings));
+    }
+}

--- a/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/Dcql/DcqlParsingTests.cs
+++ b/test/WalletFramework.Oid4Vc.Tests/Oid4Vp/Dcql/DcqlParsingTests.cs
@@ -17,7 +17,7 @@ public class DcqlParsingTests
 
         dcqlQuery.CredentialQueries[0].Id.AsString().Should().Be("pid");
         dcqlQuery.CredentialQueries[0].Format.Should().Be("dc+sd-jwt");
-        dcqlQuery.CredentialQueries[0].Meta!.Vcts!
+        dcqlQuery.CredentialQueries[0].Meta.Vcts!
             .First()
             .Should()
             .Be("https://credentials.example.com/identity_credential");
@@ -48,7 +48,7 @@ public class DcqlParsingTests
         var cred = sut.CredentialQueries[0];
         cred.Id.AsString().Should().Be("idcard");
         cred.Format.Should().Be("dc+sd-jwt");
-        cred.Meta!.Vcts!.Should().ContainSingle().Which.Should()
+        cred.Meta.Vcts!.Should().ContainSingle().Which.Should()
             .Be("ID-Card");
         cred.Claims!.Length.Should().Be(4);
         cred.Claims[0].Id!.AsString().Should().Be("a");


### PR DESCRIPTION
#### Short description of what this resolves:
- This PR makes the meta property in the CredentialQuery mandatory in order to align with the [VP1.0 spec](https://openid.github.io/OpenID4VP/openid-4-verifiable-presentations-wg-draft.html#name-credential-query). 
