### PR TITLE
Expose the RP's Access Certificate in the RpAuthResults

### DIFF
--- a/src/WalletFramework.Oid4Vc/RelyingPartyAuthentication/RpAuthResult.cs
+++ b/src/WalletFramework.Oid4Vc/RelyingPartyAuthentication/RpAuthResult.cs
@@ -39,7 +39,7 @@ public record RpAuthResult
         );
     }
 
-    public static RpAuthResult GetWithLevelUnknown() => new(RpTrustLevel.Unknown, Option<AccessCertificate>.None);
+    public static RpAuthResult GetWithLevelUnknown() => new(RpTrustLevel.Unknown, Option<AccessCertificate>.None); 
 }
 
 public static class RpAuthResultFun


### PR DESCRIPTION
#### Short description of what this resolves:
Exposes the RP's Access Certificate as a property in the RpAuthResults so the fw consumer can use it for its UI