### PR TITLE
Make ClientAttestation and WalletAttestation optional

### DIFF
--- a/src/WalletFramework.Oid4Vc/ClientAttestations/Abstractions/IClientAttestationService.cs
+++ b/src/WalletFramework.Oid4Vc/ClientAttestations/Abstractions/IClientAttestationService.cs
@@ -1,9 +1,9 @@
+using LanguageExt;
 using WalletFramework.Oid4Vc.Oid4Vci.Authorization.Models;
-using WalletFramework.Oid4Vc.WalletAttestations;
 
 namespace WalletFramework.Oid4Vc.ClientAttestations.Abstractions;
 
 public interface IClientAttestationService
 {
-    public Task<ClientAttestation> GetClientAttestation(AuthorizationServerMetadata authorizationServerMetadata);
+    public Task<Option<ClientAttestation>> GetClientAttestation(AuthorizationServerMetadata authorizationServerMetadata);
 }

--- a/src/WalletFramework.Oid4Vc/ClientAttestations/ClientAttestationService.cs
+++ b/src/WalletFramework.Oid4Vc/ClientAttestations/ClientAttestationService.cs
@@ -1,6 +1,6 @@
+using LanguageExt;
 using Microsoft.Extensions.Options;
 using WalletFramework.Core.Cryptography.Models;
-using WalletFramework.Core.Functional;
 using WalletFramework.Oid4Vc.ClientAttestations.Abstractions;
 using WalletFramework.Oid4Vc.Oid4Vci.AuthFlow.Models;
 using WalletFramework.Oid4Vc.Oid4Vci.Authorization.Models;
@@ -14,16 +14,21 @@ public class ClientAttestationService(
     IAttestationSigner attestationSigner,
     IWalletAttestationService walletAttestationService) : IClientAttestationService
 {
-    public async Task<ClientAttestation> GetClientAttestation(AuthorizationServerMetadata authorizationServerMetadata)
+    public async Task<Option<ClientAttestation>> GetClientAttestation(AuthorizationServerMetadata authorizationServerMetadata)
     {
-        var walletAttestation = (await walletAttestationService.RequestWalletAttestation()).UnwrapOrThrow();
-        
-        var walletAttestationPopJwt = await GeneratePoPJwt(
-            walletAttestation.KeyId,
-            authorizationServerMetadata.Issuer,
-            clientOptions.Value.ClientId);
+        var walletAttestation = await walletAttestationService.RequestWalletAttestation();
 
-        return ClientAttestation.Create(walletAttestation, walletAttestationPopJwt);
+        return await walletAttestation.MatchAsync<WalletAttestation, Option<ClientAttestation>>(
+            async attestation =>
+            {
+                var walletAttestationPopJwt = await GeneratePoPJwt(
+                    attestation.KeyId,
+                    authorizationServerMetadata.Issuer,
+                    clientOptions.Value.ClientId);
+
+                return ClientAttestation.Create(attestation, walletAttestationPopJwt);
+            },
+            () => Task.FromResult(Option<ClientAttestation>.None));
     }
 
     private async Task<WalletAttestationPopJwt> GeneratePoPJwt(

--- a/src/WalletFramework.Oid4Vc/Oid4Vci/AuthFlow/Models/ClientOptions.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vci/AuthFlow/Models/ClientOptions.cs
@@ -23,11 +23,6 @@ public record ClientOptions
     /// </summary>
     public string WalletIssuer { get; init; }
 
-    /// <summary>
-    ///     Enables or disables client attestation for auth/token requests.
-    /// </summary>
-    public bool ClientAttestationEnabled { get; init; }
-
 #pragma warning disable CS8618
     /// <summary>
     ///     Parameterless Default Constructor.
@@ -43,9 +38,8 @@ public record ClientOptions
     /// <param name="clientId">Identifier of the client (wallet)</param>
     /// <param name="walletIssuer">Identifier of the wallet issuer</param>
     /// <param name="redirectUri">Redirect URI that the Authorization Server will use after the authorization was successful.</param>
-    /// <param name="clientAttestationEnabled">Enables client attestation for auth/token requests.</param>
     [JsonConstructor]
-    public ClientOptions(string clientId, string walletIssuer, string redirectUri, bool clientAttestationEnabled)
+    public ClientOptions(string clientId, string walletIssuer, string redirectUri)
     {
         if (string.IsNullOrWhiteSpace(clientId)
             || string.IsNullOrWhiteSpace(walletIssuer)
@@ -57,6 +51,5 @@ public record ClientOptions
         ClientId = clientId;
         WalletIssuer = walletIssuer;
         RedirectUri = redirectUri;
-        ClientAttestationEnabled = clientAttestationEnabled;
     }
 }

--- a/src/WalletFramework.Oid4Vc/Oid4Vci/Implementations/Oid4VciClientService.cs
+++ b/src/WalletFramework.Oid4Vc/Oid4Vci/Implementations/Oid4VciClientService.cs
@@ -90,11 +90,7 @@ public class Oid4VciClientService(
         var authorizationServerMetadata =
             await FetchAuthorizationServerMetadataAsync(issuerMetadata, credentialOfferMetadata.CredentialOffer);
 
-        var clientAttestation = Option<ClientAttestation>.None;
-        if (clientOptions.Value.ClientAttestationEnabled)
-        {
-            clientAttestation = await clientAttestationService.GetClientAttestation(authorizationServerMetadata);
-        }
+        var clientAttestation = await clientAttestationService.GetClientAttestation(authorizationServerMetadata);
 
         var token = await tokenService.RequestToken(
             authorizationServerMetadata,
@@ -226,11 +222,7 @@ public class Oid4VciClientService(
 
         var authServerMetadata = await FetchAuthorizationServerMetadataAsync(issuerMetadata, offer.CredentialOffer);
         
-        var clientAttestation = Option<ClientAttestation>.None;
-        if (clientOptions.Value.ClientAttestationEnabled)
-        {
-            clientAttestation = await clientAttestationService.GetClientAttestation(authServerMetadata);
-        }
+        var clientAttestation = await clientAttestationService.GetClientAttestation(authServerMetadata);
 
         var authorizationRequestUri = await CreateAuthRequestUri(
             authServerMetadata,
@@ -299,12 +291,8 @@ public class Oid4VciClientService(
             Scope = string.Join(" ", scopes),
             ClientId = session.AuthorizationData.ClientOptions.ClientId
         };
-
-        var clientAttestation = Option<ClientAttestation>.None;
-        if (clientOptions.Value.ClientAttestationEnabled)
-        {
-            clientAttestation = await clientAttestationService.GetClientAttestation(session.AuthorizationData.AuthorizationServerMetadata);
-        }
+            
+        var clientAttestation = await clientAttestationService.GetClientAttestation(session.AuthorizationData.AuthorizationServerMetadata);
 
         var token = await tokenService.RequestToken(
             session.AuthorizationData.AuthorizationServerMetadata,
@@ -551,10 +539,7 @@ public class Oid4VciClientService(
             return new Uri(authorizationServerMetadata.AuthorizationEndpoint + vciAuthorizationRequest.ToQueryString());
         }
         
-        if (clientOptions.Value.ClientAttestationEnabled)
-        {
-            _httpClient.AddClientAttestation(clientAttestation.UnwrapOrThrow());
-        }
+        clientAttestation.IfSome(attestation => _httpClient.AddClientAttestation(attestation));
         
         var response = await _httpClient.PostAsync(
             authorizationServerMetadata.PushedAuthorizationRequestEndpoint,

--- a/src/WalletFramework.Oid4Vc/WalletAttestations/Abstractions/IWalletAttestationService.cs
+++ b/src/WalletFramework.Oid4Vc/WalletAttestations/Abstractions/IWalletAttestationService.cs
@@ -1,4 +1,4 @@
-using WalletFramework.Core.Functional;
+using LanguageExt;
 
 namespace WalletFramework.Oid4Vc.WalletAttestations.Abstractions;
 
@@ -10,5 +10,5 @@ public interface IWalletAttestationService
     /// <returns>
     ///     The wallet attestation.
     /// </returns>
-    Task<Validation<WalletAttestation>> RequestWalletAttestation();
+    Task<Option<WalletAttestation>> RequestWalletAttestation();
 }

--- a/test/WalletFramework.Storage.Tests/AuthFlowSessionRecordCrudTests.cs
+++ b/test/WalletFramework.Storage.Tests/AuthFlowSessionRecordCrudTests.cs
@@ -83,7 +83,7 @@ public class AuthFlowSessionRecordCrudTests : IDisposable
 
     private static AuthFlowSession CreateSampleSession()
     {
-        var clientOptions = new ClientOptions("client", "issuer", "https://redirect", false);
+        var clientOptions = new ClientOptions("client", "issuer", "https://redirect");
 
         var sdJwtConfig = new JObject
         {


### PR DESCRIPTION
#### Short description of what this resolves:
- Refactors the IWalletAttestationService and IClientAttestationService to make the Attestation Optional, so implementors can easily provide Shell Implementations.
