### PR TITLE
feat: add HAIP 1.0 x509_hash conformance support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+- Add HAIP 1.0 conformance support for OID4VP `x509_hash` client ID validation and OID4VCI metadata discovery.
 - Add new Strong Customer Authentication (SCA) transaction data type according to TS12
 
 #### Fixed

--- a/src/WalletFramework.Oid4Vci/Authorization/Models/AuthorizationServerId.cs
+++ b/src/WalletFramework.Oid4Vci/Authorization/Models/AuthorizationServerId.cs
@@ -2,18 +2,22 @@ using System.Globalization;
 using Newtonsoft.Json.Linq;
 using WalletFramework.Core.Functional;
 using WalletFramework.Core.Json;
-using WalletFramework.Core.Uri;
 using WalletFramework.Oid4Vci.Authorization.Errors;
 
 namespace WalletFramework.Oid4Vci.Authorization.Models;
 
 public readonly struct AuthorizationServerId
 {
+    private string OriginalString { get; }
     private Uri Value { get; }
     
-    private AuthorizationServerId(Uri value) => Value = value;
+    private AuthorizationServerId(string originalString, Uri value)
+    {
+        OriginalString = originalString;
+        Value = value;
+    }
     
-    public override string ToString() => Value.ToStringWithoutTrail();
+    public override string ToString() => OriginalString;
     
     public static implicit operator Uri(AuthorizationServerId authorizationServerId) => authorizationServerId.Value;
 
@@ -23,7 +27,7 @@ public readonly struct AuthorizationServerId
         {
             var str = value.ToString(CultureInfo.InvariantCulture);
             var uri = new Uri(str);
-            return new AuthorizationServerId(uri);
+            return new AuthorizationServerId(str, uri);
         }
         catch (Exception e)
         {

--- a/src/WalletFramework.Oid4Vci/Implementations/Oid4VciClientService.cs
+++ b/src/WalletFramework.Oid4Vci/Implementations/Oid4VciClientService.cs
@@ -27,6 +27,7 @@ using WalletFramework.Oid4Vci.CredOffer.Models;
 using WalletFramework.Oid4Vci.CredRequest.Abstractions;
 using WalletFramework.Oid4Vci.Issuer.Abstractions;
 using WalletFramework.Oid4Vci.Issuer.Models;
+using WalletFramework.Oid4Vci.Metadata;
 using WalletFramework.SdJwtVc.Persistence;
 using WalletFramework.Storage;
 using WalletFramework.WalletAttestations;
@@ -144,7 +145,7 @@ public class Oid4VciClientService(
                                         creds.Count > 1,
                                         Option<DateTime>.None);
 
-                                        await mdocCredentialStore.Add(mdocCredential);
+                                    await mdocCredentialStore.Add(mdocCredential);
                                     records.Add(mdocCredential);
                                 });
                         }
@@ -228,7 +229,7 @@ public class Oid4VciClientService(
             null);
 
         var authServerMetadata = await FetchAuthorizationServerMetadataAsync(issuerMetadata, offer.CredentialOffer);
-        
+
         var clientAttestation = await clientAttestationService.GetClientAttestation(
             new ClientAttestationRequest(authServerMetadata.Issuer));
 
@@ -300,7 +301,7 @@ public class Oid4VciClientService(
             Scope = string.Join(" ", scopes),
             ClientId = session.AuthorizationData.ClientOptions.ClientId
         };
-            
+
         var clientAttestation = await clientAttestationService.GetClientAttestation(
             new ClientAttestationRequest(session.AuthorizationData.AuthorizationServerMetadata.Issuer));
 
@@ -436,34 +437,20 @@ public class Oid4VciClientService(
         return new AuthorizationCodeParameters(codeChallenge, codeVerifier);
     }
 
-    private static Uri CreateAuthorizationServerMetadataUri(Uri authorizationServerUri)
-    {
-        string result;
-        if (string.IsNullOrWhiteSpace(authorizationServerUri.AbsolutePath) ||
-            authorizationServerUri.AbsolutePath == "/")
-            result =
-                $"{authorizationServerUri.GetLeftPart(UriPartial.Authority)}/.well-known/oauth-authorization-server";
-        else
-            result =
-                $"{authorizationServerUri.GetLeftPart(UriPartial.Authority)}/.well-known/oauth-authorization-server" +
-                authorizationServerUri.AbsolutePath.TrimEnd('/');
-        return new Uri(result);
-    }
-
     private async Task<AuthorizationServerMetadata> FetchAuthorizationServerMetadataAsync(
         IssuerMetadata issuerMetadata,
         Option<CredentialOffer> credentialOffer)
     {
         Uri credentialIssuer = issuerMetadata.CredentialIssuer;
 
-        var authServerUrls = issuerMetadata.AuthorizationServers.Match(
+        IEnumerable<Uri> authServerUrls = issuerMetadata.AuthorizationServers.Match(
             issuerMetadataAuthServers =>
             {
                 var credentialOfferAuthServer = from offer in credentialOffer
-                    from grants in offer.Grants
-                    from code in grants.AuthorizationCode
-                    from server in code.AuthorizationServer
-                    select server;
+                                                from grants in offer.Grants
+                                                from code in grants.AuthorizationCode
+                                                from server in code.AuthorizationServer
+                                                select server;
 
                 return credentialOfferAuthServer.Match(
                     offerAuthServer =>
@@ -472,14 +459,14 @@ public class Oid4VciClientService(
                             issuerMetadataAuthServer.ToString() == offerAuthServer);
 
                         return matchingAuthServer.Match(
-                            Some: server => new List<Uri> { CreateAuthorizationServerMetadataUri(server) },
+                            Some: server => new List<Uri> { MetadataDiscoveryUrl.ForAuthorizationServer((Uri)server) },
                             None: () => throw new InvalidOperationException(
                                 "The authorization server in the credential offer does not match any authorization server in the issuer metadata."));
                     },
-                    () => issuerMetadataAuthServers.Select(uri => CreateAuthorizationServerMetadataUri(uri))
+                    () => issuerMetadataAuthServers.Select(server => MetadataDiscoveryUrl.ForAuthorizationServer((Uri)server))
                 );
             },
-            () => [CreateAuthorizationServerMetadataUri(credentialIssuer)]);
+            () => [MetadataDiscoveryUrl.ForAuthorizationServer(credentialIssuer)]);
 
 
         var authorizationServerMetadatas = new List<AuthorizationServerMetadata>();
@@ -503,8 +490,8 @@ public class Oid4VciClientService(
             Some: offer =>
             {
                 var credentialOfferAuthCodeGrantType = from grants in offer.Grants
-                    from code in grants.AuthorizationCode
-                    select code;
+                                                       from code in grants.AuthorizationCode
+                                                       select code;
 
                 return credentialOfferAuthCodeGrantType.Match(
                     Some: code => code.AuthorizationServer.Match(
@@ -518,8 +505,8 @@ public class Oid4VciClientService(
                     None: () =>
                     {
                         var credentialOfferPreAuthGrantType = from grants in offer.Grants
-                            from code in grants.PreAuthorizedCode
-                            select code;
+                                                              from code in grants.PreAuthorizedCode
+                                                              select code;
 
                         return credentialOfferPreAuthGrantType.Match(
                             Some: preAuth =>
@@ -555,17 +542,29 @@ public class Oid4VciClientService(
         {
             return new Uri(authorizationServerMetadata.AuthorizationEndpoint + vciAuthorizationRequest.ToQueryString());
         }
-        
+
         clientAttestation.IfSome(attestation => _httpClient.AddClientAttestation(attestation));
-        
+
         var response = await _httpClient.PostAsync(
             authorizationServerMetadata.PushedAuthorizationRequestEndpoint,
             vciAuthorizationRequest.ToFormUrlEncoded()
         );
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"PAR request failed with status code {(int)response.StatusCode} ({response.StatusCode}). Response body: {responseBody}");
+        }
 
         var parResponse =
-            DeserializeObject<PushedAuthorizationRequestResponse>(await response.Content.ReadAsStringAsync())
+            DeserializeObject<PushedAuthorizationRequestResponse>(responseBody)
             ?? throw new InvalidOperationException("Failed to deserialize the PAR response.");
+
+        if (parResponse.RequestUri is null)
+        {
+            throw new InvalidOperationException($"PAR response did not contain a request_uri. Response body: {responseBody}");
+        }
 
         return new Uri(authorizationServerMetadata.AuthorizationEndpoint
                        + "?client_id=" + vciAuthorizationRequest.ClientId

--- a/src/WalletFramework.Oid4Vci/Issuer/Implementations/IssuerMetadataService.cs
+++ b/src/WalletFramework.Oid4Vci/Issuer/Implementations/IssuerMetadataService.cs
@@ -1,5 +1,6 @@
 using WalletFramework.Core.Functional;
 using WalletFramework.Core.Localization;
+using WalletFramework.Oid4Vci.Metadata;
 using WalletFramework.Oid4Vci.Issuer.Abstractions;
 using WalletFramework.Oid4Vci.Issuer.Models;
 using static WalletFramework.Core.Json.JsonFun;
@@ -13,13 +14,7 @@ public class IssuerMetadataService(IHttpClientFactory httpClientFactory) : IIssu
     
     public async Task<Validation<IssuerMetadata>> ProcessMetadata(Uri issuerEndpoint, Locale language)
     {
-        var baseEndpoint = issuerEndpoint
-            .AbsolutePath
-            .EndsWith("/")
-            ? issuerEndpoint
-            : new Uri(issuerEndpoint.OriginalString + "/");
-        
-        var metadataUrl = new Uri(baseEndpoint, ".well-known/openid-credential-issuer");
+        var metadataUrl = MetadataDiscoveryUrl.ForCredentialIssuer(issuerEndpoint);
         
         _httpClient.DefaultRequestHeaders.Add("Accept-Language", language);
         

--- a/src/WalletFramework.Oid4Vci/Issuer/Models/CredentialIssuerId.cs
+++ b/src/WalletFramework.Oid4Vci/Issuer/Models/CredentialIssuerId.cs
@@ -2,18 +2,22 @@ using System.Globalization;
 using Newtonsoft.Json.Linq;
 using WalletFramework.Core.Functional;
 using WalletFramework.Core.Json;
-using WalletFramework.Core.Uri;
 using WalletFramework.Oid4Vci.Issuer.Errors;
 
 namespace WalletFramework.Oid4Vci.Issuer.Models;
 
 public readonly struct CredentialIssuerId
 {
+    private string OriginalString { get; }
     private Uri Value { get; }
     
-    private CredentialIssuerId(Uri value) => Value = value;
+    private CredentialIssuerId(string originalString, Uri value)
+    {
+        OriginalString = originalString;
+        Value = value;
+    }
 
-    public override string ToString() => Value.ToStringWithoutTrail();
+    public override string ToString() => OriginalString;
     
     public static implicit operator Uri(CredentialIssuerId credentialIssuerId) => credentialIssuerId.Value;
 
@@ -23,7 +27,7 @@ public readonly struct CredentialIssuerId
         {
             var str = value.ToString(CultureInfo.InvariantCulture);
             var uri = new Uri(str);
-            return new CredentialIssuerId(uri);
+            return new CredentialIssuerId(str, uri);
         }
         catch (Exception e)
         {

--- a/src/WalletFramework.Oid4Vci/Metadata/MetadataDiscoveryUrl.cs
+++ b/src/WalletFramework.Oid4Vci/Metadata/MetadataDiscoveryUrl.cs
@@ -1,0 +1,28 @@
+namespace WalletFramework.Oid4Vci.Metadata;
+
+internal static class MetadataDiscoveryUrl
+{
+    private const string CredentialIssuerWellKnownPath = "/.well-known/openid-credential-issuer";
+    private const string AuthorizationServerWellKnownPath = "/.well-known/oauth-authorization-server";
+
+    public static Uri ForCredentialIssuer(Uri issuerIdentifier) =>
+        Create(issuerIdentifier, CredentialIssuerWellKnownPath);
+
+    public static Uri ForAuthorizationServer(Uri issuerIdentifier) =>
+        Create(issuerIdentifier, AuthorizationServerWellKnownPath);
+
+    private static Uri Create(Uri issuerIdentifier, string wellKnownPath)
+    {
+        var issuerPath = issuerIdentifier.AbsolutePath;
+        var metadataPath = string.IsNullOrWhiteSpace(issuerPath) || issuerPath == "/"
+            ? wellKnownPath
+            : $"{wellKnownPath}{issuerPath}";
+
+        return new UriBuilder(issuerIdentifier)
+        {
+            Path = metadataPath,
+            Query = string.Empty,
+            Fragment = string.Empty
+        }.Uri;
+    }
+}

--- a/src/WalletFramework.Oid4Vci/WalletFramework.Oid4Vci.csproj
+++ b/src/WalletFramework.Oid4Vci/WalletFramework.Oid4Vci.csproj
@@ -7,6 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+        <_Parameter1>WalletFramework.Oid4Vci.Tests</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+
+    <ItemGroup>
       <ProjectReference Include="..\WalletFramework.Credentials\WalletFramework.Credentials.csproj" />
       <ProjectReference Include="..\WalletFramework.WalletAttestations\WalletFramework.WalletAttestations.csproj" />
     </ItemGroup>

--- a/src/WalletFramework.Oid4Vp/Models/AuthorizationRequest.cs
+++ b/src/WalletFramework.Oid4Vp/Models/AuthorizationRequest.cs
@@ -28,7 +28,7 @@ public record AuthorizationRequest
     public const string DcApiJwt = "dc_api.jwt";
 
     private static readonly string[] SupportedClientIdSchemes =
-        [RedirectUriScheme, VerifierAttestationScheme, X509SanDnsScheme];
+        [RedirectUriScheme, VerifierAttestationScheme, X509SanDnsScheme, X509HashScheme];
 
     /// <summary>
     ///     Gets the client id scheme.

--- a/src/WalletFramework.Oid4Vp/Models/ClientIdScheme.cs
+++ b/src/WalletFramework.Oid4Vp/Models/ClientIdScheme.cs
@@ -18,6 +18,11 @@ public record ClientIdScheme
         X509SanDns,
 
         /// <summary>
+        ///     The X509 hash client ID scheme.
+        /// </summary>
+        X509Hash,
+
+        /// <summary>
         ///     The verifier attestation client ID scheme.
         /// </summary>
         VerifierAttestation,
@@ -42,6 +47,11 @@ public record ClientIdScheme
     ///     The X509 SAN DNS scheme.
     /// </summary>
     public const string X509SanDnsScheme = "x509_san_dns";
+
+    /// <summary>
+    ///     The X509 hash scheme.
+    /// </summary>
+    public const string X509HashScheme = "x509_hash";
         
     /// <summary>
     ///     The Redirect Uri scheme.
@@ -73,6 +83,7 @@ public record ClientIdScheme
         input switch
         {
             X509SanDnsScheme => new ClientIdScheme(X509SanDns),
+            X509HashScheme => new ClientIdScheme(X509Hash),
             RedirectUriScheme => new ClientIdScheme(RedirectUri),
             DidScheme => new ClientIdScheme(Did),
             VerifierAttestationScheme =>
@@ -92,6 +103,7 @@ public record ClientIdScheme
         => clientIdScheme.Value switch
         {
             X509SanDns => X509SanDnsScheme,
+            X509Hash => X509HashScheme,
             RedirectUri => RedirectUriScheme,
             Did => DidScheme,
             ClientIdSchemeValue.VerifierAttestation => VerifierAttestationScheme,

--- a/src/WalletFramework.Oid4Vp/Models/RequestObject.cs
+++ b/src/WalletFramework.Oid4Vp/Models/RequestObject.cs
@@ -3,6 +3,8 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using LanguageExt;
 using Org.BouncyCastle.X509;
+using WalletFramework.Core.Base64Url;
+using WalletFramework.Core.Encoding;
 using WalletFramework.Core.Functional;
 using WalletFramework.Core.X509;
 using WalletFramework.Oid4Vp.DcApi.Models;
@@ -176,6 +178,22 @@ public static class RequestObjectExtensions
             .Any(sanDnsName => requestObject.ClientId.EndsWith(sanDnsName.Split("*").Last()))
             ? requestObject
             : throw new InvalidOperationException("SAN does not match Client ID");
+    }
+
+    /// <summary>
+    ///     Validates that the client ID equals the base64url-encoded SHA-256 hash of the DER-encoded leaf certificate.
+    /// </summary>
+    /// <returns>The validated request object</returns>
+    /// <exception cref="InvalidOperationException">Throws when validation fails</exception>
+    public static RequestObject ValidateCertificateHash(this RequestObject requestObject)
+    {
+        var leafCertificateDer = requestObject.GetLeafCertificate().GetEncoded();
+        var leafCertificateHash = Sha256Hash.ComputeHash(leafCertificateDer);
+        var expectedClientId = Base64UrlString.CreateBase64UrlString(leafCertificateHash.AsBytes).AsString;
+
+        return requestObject.ClientId == expectedClientId
+            ? requestObject
+            : throw new InvalidOperationException("Leaf certificate hash does not match Client ID");
     }
 
     /// <summary>

--- a/src/WalletFramework.Oid4Vp/Services/AuthorizationRequestService.cs
+++ b/src/WalletFramework.Oid4Vp/Services/AuthorizationRequestService.cs
@@ -56,9 +56,12 @@ public class AuthorizationRequestService(
                 return (await FetchClientMetadata(authRequest)
                     .OnException(_ => Option<ClientMetadata>.None))
                     .Match(
-                        clientMetadataOption => 
+                        clientMetadataOption =>
                         {
                             var error = new InvalidRequestError($"Client ID Scheme {requestObject.ClientIdScheme} is not supported");
+
+                            if (authRequest.ClientIdScheme is null)
+                                return new AuthorizationRequestCancellation(authRequest.GetResponseUriMaybe(), [error]);
 
                             Validation<AuthorizationRequestCancellation, RequestObject> result;
                             try
@@ -135,8 +138,11 @@ public class AuthorizationRequestService(
                         clientMetadataOption =>
                         {
                             var error = new InvalidRequestError($"Client ID Scheme {authRequest.ClientIdScheme} is not supported");
-                
-                            Validation<AuthorizationRequestCancellation, AuthorizationRequest> result = 
+
+                            if (authRequest.ClientIdScheme is null)
+                                return new AuthorizationRequestCancellation(authRequest.GetResponseUriMaybe(), [error]);
+
+                            Validation<AuthorizationRequestCancellation, AuthorizationRequest> result =
                                 authRequest.ClientIdScheme.Value switch
                                 {
                                     RedirectUri => authRequest.WithClientMetadata(clientMetadataOption),

--- a/src/WalletFramework.Oid4Vp/Services/AuthorizationRequestService.cs
+++ b/src/WalletFramework.Oid4Vp/Services/AuthorizationRequestService.cs
@@ -58,41 +58,42 @@ public class AuthorizationRequestService(
                     .Match(
                         clientMetadataOption =>
                         {
-                            var error = new InvalidRequestError($"Client ID Scheme {requestObject.ClientIdScheme} is not supported");
-
-                            if (authRequest.ClientIdScheme is null)
+                            if (authRequest.ClientIdScheme is not { } clientIdScheme)
+                            {
+                                var error = new InvalidRequestError(
+                                    $"Client ID Scheme {authRequest.ClientIdScheme} is not supported");
                                 return new AuthorizationRequestCancellation(authRequest.GetResponseUriMaybe(), [error]);
+                            }
+
+                            var unsupportedSchemeError = new InvalidRequestError(
+                                $"Client ID Scheme {clientIdScheme.AsString()} is not supported");
 
                             Validation<AuthorizationRequestCancellation, RequestObject> result;
                             try
                             {
-                                result = requestObject.ClientIdScheme.Value switch
+                                result = clientIdScheme.Value switch
                                 {
-                                    X509SanDns => requestObject
-                                        .ValidateJwtSignature()
-                                        .ValidateTrustChain()
-                                        .ValidateSanName()
-                                        .WithX509()
-                                        .WithClientMetadata(clientMetadataOption),
-                                    X509Hash => requestObject
-                                        .ValidateJwtSignature()
-                                        .ValidateTrustChain()
-                                        .ValidateCertificateHash()
-                                        .WithX509()
-                                        .WithClientMetadata(clientMetadataOption),
+                                    X509SanDns => ValidateSignedX509Request(
+                                        requestObject,
+                                        request => request.ValidateSanName(),
+                                        clientMetadataOption),
+                                    X509Hash => ValidateSignedX509Request(
+                                        requestObject,
+                                        request => request.ValidateCertificateHash(),
+                                        clientMetadataOption),
                                     RedirectUri => requestObject
                                         .ValidateClientIdPrefix()
                                         .WithClientMetadata(clientMetadataOption),
                                     //TODO: Remove Did in the future (kept for now for compatibility)
                                     Did => requestObject
                                         .WithClientMetadata(clientMetadataOption),
-                                    _ => new AuthorizationRequestCancellation(authRequest.GetResponseUriMaybe(), [error])
+                                    _ => new AuthorizationRequestCancellation(authRequest.GetResponseUriMaybe(), [unsupportedSchemeError])
                                 };
                             }
                             catch (Exception exception)
                             {
                                 var validationError = new InvalidRequestError(
-                                    $"Validation of the request object for Client ID Scheme {requestObject.ClientIdScheme} failed",
+                                    $"Validation of the request object for Client ID Scheme {clientIdScheme.AsString()} failed",
                                     exception);
                                 result = new AuthorizationRequestCancellation(
                                     authRequest.GetResponseUriMaybe(), [validationError]);
@@ -103,6 +104,20 @@ public class AuthorizationRequestService(
                         cancellation => cancellation);
             },
             seq => seq);
+    }
+
+    private static RequestObject ValidateSignedX509Request(
+        RequestObject requestObject,
+        Func<RequestObject, RequestObject> validateClientIdentity,
+        Option<ClientMetadata> clientMetadataOption)
+    {
+        var signedRequestObject = requestObject
+            .ValidateJwtSignature()
+            .ValidateTrustChain();
+
+        return validateClientIdentity(signedRequestObject)
+            .WithX509()
+            .WithClientMetadata(clientMetadataOption);
     }
 
     private async Task<Validation<AuthorizationRequestCancellation, AuthorizationRequest>> GetAuthRequestByValue(

--- a/src/WalletFramework.Oid4Vp/Services/AuthorizationRequestService.cs
+++ b/src/WalletFramework.Oid4Vp/Services/AuthorizationRequestService.cs
@@ -59,24 +59,41 @@ public class AuthorizationRequestService(
                         clientMetadataOption => 
                         {
                             var error = new InvalidRequestError($"Client ID Scheme {requestObject.ClientIdScheme} is not supported");
-    
-                Validation<AuthorizationRequestCancellation, RequestObject> result = 
-                    requestObject.ClientIdScheme.Value switch
-                    {
-                        X509SanDns => requestObject
-                            .ValidateJwtSignature()
-                            .ValidateTrustChain()
-                            .ValidateSanName()
-                            .WithX509()
-                            .WithClientMetadata(clientMetadataOption),
-                        RedirectUri => requestObject
-                            .ValidateClientIdPrefix()
-                            .WithClientMetadata(clientMetadataOption),
-                        //TODO: Remove Did in the future (kept for now for compatibility)
-                        Did => requestObject
-                            .WithClientMetadata(clientMetadataOption),
-                        _ => new AuthorizationRequestCancellation(authRequest.GetResponseUriMaybe(), [error])
-                    };
+
+                            Validation<AuthorizationRequestCancellation, RequestObject> result;
+                            try
+                            {
+                                result = requestObject.ClientIdScheme.Value switch
+                                {
+                                    X509SanDns => requestObject
+                                        .ValidateJwtSignature()
+                                        .ValidateTrustChain()
+                                        .ValidateSanName()
+                                        .WithX509()
+                                        .WithClientMetadata(clientMetadataOption),
+                                    X509Hash => requestObject
+                                        .ValidateJwtSignature()
+                                        .ValidateTrustChain()
+                                        .ValidateCertificateHash()
+                                        .WithX509()
+                                        .WithClientMetadata(clientMetadataOption),
+                                    RedirectUri => requestObject
+                                        .ValidateClientIdPrefix()
+                                        .WithClientMetadata(clientMetadataOption),
+                                    //TODO: Remove Did in the future (kept for now for compatibility)
+                                    Did => requestObject
+                                        .WithClientMetadata(clientMetadataOption),
+                                    _ => new AuthorizationRequestCancellation(authRequest.GetResponseUriMaybe(), [error])
+                                };
+                            }
+                            catch (Exception exception)
+                            {
+                                var validationError = new InvalidRequestError(
+                                    $"Validation of the request object for Client ID Scheme {requestObject.ClientIdScheme} failed",
+                                    exception);
+                                result = new AuthorizationRequestCancellation(
+                                    authRequest.GetResponseUriMaybe(), [validationError]);
+                            }
 
                             return result;
                         },

--- a/test/WalletFramework.Oid4Vci.Tests/Authorization/AuthorizationServerIdTests.cs
+++ b/test/WalletFramework.Oid4Vci.Tests/Authorization/AuthorizationServerIdTests.cs
@@ -1,0 +1,24 @@
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using WalletFramework.Core.Functional;
+using WalletFramework.Oid4Vci.Authorization.Models;
+using Xunit;
+
+namespace WalletFramework.Oid4Vci.Tests.Authorization;
+
+public class AuthorizationServerIdTests
+{
+    [Fact(DisplayName = "authorization server identifiers preserve trailing slashes")]
+    public void AuthorizationServerIdentifiersPreserveTrailingSlashes()
+    {
+        const string issuer = "https://test-issuer.com/test/a/sdjwtEncrypted/";
+
+        var authorizationServerId = AuthorizationServerId
+            .ValidAuthorizationServerId(new JValue(issuer))
+            .UnwrapOrThrow(new InvalidOperationException());
+        Uri parsedUri = authorizationServerId;
+
+        authorizationServerId.ToString().Should().Be(issuer);
+        parsedUri.Should().Be(new Uri(issuer));
+    }
+}

--- a/test/WalletFramework.Oid4Vci.Tests/Issuer/CredentialIssuerIdTests.cs
+++ b/test/WalletFramework.Oid4Vci.Tests/Issuer/CredentialIssuerIdTests.cs
@@ -1,0 +1,24 @@
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using WalletFramework.Core.Functional;
+using WalletFramework.Oid4Vci.Issuer.Models;
+using Xunit;
+
+namespace WalletFramework.Oid4Vci.Tests.Issuer;
+
+public class CredentialIssuerIdTests
+{
+    [Fact(DisplayName = "credential issuer identifiers preserve trailing slashes")]
+    public void CredentialIssuerIdentifiersPreserveTrailingSlashes()
+    {
+        const string issuer = "https://test-issuer.com/test/a/sdjwtEncrypted/";
+
+        var credentialIssuerId = CredentialIssuerId
+            .ValidCredentialIssuerId(new JValue(issuer))
+            .UnwrapOrThrow(new InvalidOperationException());
+        Uri parsedUri = credentialIssuerId;
+
+        credentialIssuerId.ToString().Should().Be(issuer);
+        parsedUri.Should().Be(new Uri(issuer));
+    }
+}

--- a/test/WalletFramework.Oid4Vci.Tests/Issuer/IssuerMetadataServiceTests.cs
+++ b/test/WalletFramework.Oid4Vci.Tests/Issuer/IssuerMetadataServiceTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using WalletFramework.Oid4Vci.Issuer.Implementations;
+using WalletFramework.Oid4Vci.Tests.Issuer.Samples;
+using WalletFramework.Oid4Vci.Tests.Localization.Samples;
+using Xunit;
+
+namespace WalletFramework.Oid4Vci.Tests.Issuer;
+
+public class IssuerMetadataServiceTests
+{
+    [Theory(DisplayName = "credential issuer metadata is discovered through the authority well-known path")]
+    [InlineData(
+        "https://issuer.example.com/tenant",
+        "https://issuer.example.com/.well-known/openid-credential-issuer/tenant")]
+    [InlineData(
+        "https://issuer.example.com/tenant/",
+        "https://issuer.example.com/.well-known/openid-credential-issuer/tenant/")]
+    [InlineData(
+        "https://issuer.example.com",
+        "https://issuer.example.com/.well-known/openid-credential-issuer")]
+    public async Task CredentialIssuerMetadataIsDiscoveredThroughTheAuthorityWellKnownPath(
+        string issuer,
+        string expectedMetadataUrl)
+    {
+        var requestedUri = default(Uri);
+        var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+        httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((request, _) => requestedUri = request.RequestUri)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(IssuerMetadataSample.EncodedAsJson.ToString())
+            });
+
+        var httpClient = new HttpClient(httpMessageHandlerMock.Object);
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        httpClientFactoryMock
+            .Setup(factory => factory.CreateClient(It.IsAny<string>()))
+            .Returns(httpClient);
+        var sut = new IssuerMetadataService(httpClientFactoryMock.Object);
+
+        await sut.ProcessMetadata(new Uri(issuer), LocaleSample.English);
+
+        requestedUri.Should().Be(new Uri(expectedMetadataUrl));
+    }
+}

--- a/test/WalletFramework.Oid4Vci.Tests/Issuer/IssuerMetadataTests.cs
+++ b/test/WalletFramework.Oid4Vci.Tests/Issuer/IssuerMetadataTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Newtonsoft.Json.Linq;
 using WalletFramework.Core.Functional;
 using WalletFramework.Oid4Vci.Issuer.Models;
 using WalletFramework.Oid4Vci.Tests.CredConfiguration.Mdoc.Samples;
@@ -6,6 +7,7 @@ using WalletFramework.Oid4Vci.Tests.CredConfiguration.SdJwt.Samples;
 using WalletFramework.Oid4Vci.Tests.Issuer.Samples;
 using Xunit;
 using static WalletFramework.Oid4Vci.Issuer.Models.IssuerMetadata;
+using static WalletFramework.Oid4Vci.Issuer.Models.IssuerMetadataJsonExtensions;
 
 namespace WalletFramework.Oid4Vci.Tests.Issuer;
 
@@ -65,6 +67,27 @@ public class IssuerMetadataTests
             {
                 var sut = issuerMetadata.EncodeToJson();
                 sut.Should().BeEquivalentTo(sample);
+            },
+            _ => Assert.Fail("IssuerMetadata must be valid"));
+    }
+
+    [Fact(DisplayName = "issuer metadata preserves trailing slashes in issuer identifiers")]
+    public void IssuerMetadataPreservesTrailingSlashesInIssuerIdentifiers()
+    {
+        const string credentialIssuer = "https://test-issuer.de/test/a/sdjwtEncrypted/";
+        const string authorizationServer = "https://test-issuer.com/authorizationserver/";
+        var sample = (JObject)IssuerMetadataSample.EncodedAsJson.DeepClone();
+        sample[CredentialIssuerJsonKey] = credentialIssuer;
+        sample[AuthorizationServersJsonKey] = new JArray(authorizationServer);
+
+        ValidIssuerMetadata(sample).Match(
+            issuerMetadata =>
+            {
+                var encoded = issuerMetadata.EncodeToJson();
+
+                issuerMetadata.CredentialIssuer.ToString().Should().Be(credentialIssuer);
+                encoded[CredentialIssuerJsonKey]!.Value<string>().Should().Be(credentialIssuer);
+                encoded[AuthorizationServersJsonKey]!.Single()!.Value<string>().Should().Be(authorizationServer);
             },
             _ => Assert.Fail("IssuerMetadata must be valid"));
     }

--- a/test/WalletFramework.Oid4Vci.Tests/Metadata/MetadataDiscoveryUrlTests.cs
+++ b/test/WalletFramework.Oid4Vci.Tests/Metadata/MetadataDiscoveryUrlTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using WalletFramework.Oid4Vci.Metadata;
+using Xunit;
+
+namespace WalletFramework.Oid4Vci.Tests.Metadata;
+
+public class MetadataDiscoveryUrlTests
+{
+    [Theory(DisplayName = "credential issuer metadata discovery preserves the issuer path shape")]
+    [InlineData(
+        "https://issuer.example.com",
+        "https://issuer.example.com/.well-known/openid-credential-issuer")]
+    [InlineData(
+        "https://issuer.example.com/",
+        "https://issuer.example.com/.well-known/openid-credential-issuer")]
+    [InlineData(
+        "https://issuer.example.com/test/a/sdjwtEncrypted",
+        "https://issuer.example.com/.well-known/openid-credential-issuer/test/a/sdjwtEncrypted")]
+    [InlineData(
+        "https://issuer.example.com/test/a/sdjwtEncrypted/",
+        "https://issuer.example.com/.well-known/openid-credential-issuer/test/a/sdjwtEncrypted/")]
+    [InlineData(
+        "https://issuer.example.com/test/a/sdjwtEncrypted/?query=value#fragment",
+        "https://issuer.example.com/.well-known/openid-credential-issuer/test/a/sdjwtEncrypted/")]
+    public void CredentialIssuerMetadataDiscoveryPreservesTheIssuerPathShape(
+        string issuerIdentifier,
+        string expectedMetadataUrl)
+    {
+        var issuer = new Uri(issuerIdentifier);
+
+        var metadataUrl = MetadataDiscoveryUrl.ForCredentialIssuer(issuer);
+
+        metadataUrl.Should().Be(new Uri(expectedMetadataUrl));
+    }
+
+    [Theory(DisplayName = "authorization server metadata discovery preserves the issuer path shape")]
+    [InlineData(
+        "https://issuer.example.com",
+        "https://issuer.example.com/.well-known/oauth-authorization-server")]
+    [InlineData(
+        "https://issuer.example.com/",
+        "https://issuer.example.com/.well-known/oauth-authorization-server")]
+    [InlineData(
+        "https://issuer.example.com/test/a/sdjwtEncrypted",
+        "https://issuer.example.com/.well-known/oauth-authorization-server/test/a/sdjwtEncrypted")]
+    [InlineData(
+        "https://issuer.example.com/test/a/sdjwtEncrypted/",
+        "https://issuer.example.com/.well-known/oauth-authorization-server/test/a/sdjwtEncrypted/")]
+    [InlineData(
+        "https://issuer.example.com/test/a/sdjwtEncrypted/?query=value#fragment",
+        "https://issuer.example.com/.well-known/oauth-authorization-server/test/a/sdjwtEncrypted/")]
+    public void AuthorizationServerMetadataDiscoveryPreservesTheIssuerPathShape(
+        string issuerIdentifier,
+        string expectedMetadataUrl)
+    {
+        var issuer = new Uri(issuerIdentifier);
+
+        var metadataUrl = MetadataDiscoveryUrl.ForAuthorizationServer(issuer);
+
+        metadataUrl.Should().Be(new Uri(expectedMetadataUrl));
+    }
+}

--- a/test/WalletFramework.Oid4Vci.Tests/WalletFramework.Oid4Vci.Tests.csproj
+++ b/test/WalletFramework.Oid4Vci.Tests/WalletFramework.Oid4Vci.Tests.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/WalletFramework.Oid4Vp.Tests/AuthRequest/AuthorizationRequestServiceFactory.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/AuthRequest/AuthorizationRequestServiceFactory.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using Moq;
+using Moq.Protected;
+using WalletFramework.Oid4Vp.Models;
+using WalletFramework.Oid4Vp.RelyingPartyAuthentication;
+using WalletFramework.Oid4Vp.RelyingPartyAuthentication.Abstractions;
+using WalletFramework.Oid4Vp.Services;
+
+namespace WalletFramework.Oid4Vp.Tests.AuthRequest;
+
+internal static class AuthorizationRequestServiceFactory
+{
+    private const string SendAsyncMethodName = "SendAsync";
+
+    internal static AuthorizationRequestService CreateServiceReturning(string requestObjectJwt)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                SendAsyncMethodName,
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(requestObjectJwt)
+            });
+
+        var httpClientFactory = new Mock<IHttpClientFactory>();
+        httpClientFactory
+            .Setup(factory => factory.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler.Object));
+
+        var rpAuthService = new Mock<IRpAuthService>();
+        rpAuthService
+            .Setup(service => service.Authenticate(It.IsAny<RequestObject>()))
+            .ReturnsAsync(RpAuthResult.GetWithLevelUnknown());
+
+        return new AuthorizationRequestService(httpClientFactory.Object, rpAuthService.Object);
+    }
+}

--- a/test/WalletFramework.Oid4Vp.Tests/AuthRequest/Samples/UnresolvedClientIdSchemeSamples.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/AuthRequest/Samples/UnresolvedClientIdSchemeSamples.cs
@@ -1,0 +1,42 @@
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
+
+namespace WalletFramework.Oid4Vp.Tests.AuthRequest.Samples;
+
+public static class UnresolvedClientIdSchemeSamples
+{
+    private const string ResponseUri = "https://verifier.example.com/response";
+
+    public static string RequestObjectWithoutClientId()
+    {
+        var payload = new JwtPayload
+        {
+            { "response_uri", ResponseUri },
+            { "nonce", "test-nonce-value" },
+            { "response_mode", "direct_post.jwt" }
+        };
+
+        return BuildUnsignedRequestObject(payload);
+    }
+
+    public static string RequestObjectWithUnsupportedClientIdPrefix()
+    {
+        var payload = new JwtPayload
+        {
+            { "response_uri", ResponseUri },
+            { "client_id", "unknown_scheme:verifier.example.com" },
+            { "nonce", "test-nonce-value" },
+            { "response_mode", "direct_post.jwt" }
+        };
+
+        return BuildUnsignedRequestObject(payload);
+    }
+
+    private static string BuildUnsignedRequestObject(JwtPayload payload)
+    {
+        var encodedHeader = Base64UrlEncoder.Encode("{\"alg\":\"none\",\"typ\":\"JWT\"}");
+        var encodedPayload = Base64UrlEncoder.Encode(payload.SerializeToJson());
+
+        return $"{encodedHeader}.{encodedPayload}";
+    }
+}

--- a/test/WalletFramework.Oid4Vp.Tests/AuthRequest/Samples/X509HashSamples.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/AuthRequest/Samples/X509HashSamples.cs
@@ -2,17 +2,19 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.Tokens;
+using WalletFramework.Oid4Vp.Models;
 
 namespace WalletFramework.Oid4Vp.Tests.AuthRequest.Samples;
 
 public static class X509HashSamples
 {
     private const string ResponseUri = "https://verifier.example.com/response";
+    private const string MismatchedCertificateHash = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     public static string SignedRequestObjectWithMatchingCertificateHash()
     {
         var chain = CreateLeafSignedByCa();
-        var clientId = $"x509_hash:{LeafCertificateHash(chain.Leaf)}";
+        var clientId = $"{ClientIdScheme.X509HashScheme}:{LeafCertificateHash(chain.Leaf)}";
 
         return BuildSignedRequestObject(clientId, chain, includeX5c: true);
     }
@@ -20,7 +22,7 @@ public static class X509HashSamples
     public static string SignedRequestObjectWithMismatchedCertificateHash()
     {
         var chain = CreateLeafSignedByCa();
-        const string clientId = "x509_hash:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        var clientId = $"{ClientIdScheme.X509HashScheme}:{MismatchedCertificateHash}";
 
         return BuildSignedRequestObject(clientId, chain, includeX5c: true);
     }
@@ -28,7 +30,7 @@ public static class X509HashSamples
     public static string SignedRequestObjectWithoutX5c()
     {
         var chain = CreateLeafSignedByCa();
-        const string clientId = "x509_hash:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        var clientId = $"{ClientIdScheme.X509HashScheme}:{MismatchedCertificateHash}";
 
         return BuildSignedRequestObject(clientId, chain, includeX5c: false);
     }

--- a/test/WalletFramework.Oid4Vp.Tests/AuthRequest/Samples/X509HashSamples.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/AuthRequest/Samples/X509HashSamples.cs
@@ -1,0 +1,103 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.IdentityModel.Tokens;
+
+namespace WalletFramework.Oid4Vp.Tests.AuthRequest.Samples;
+
+public static class X509HashSamples
+{
+    private const string ResponseUri = "https://verifier.example.com/response";
+
+    public static string SignedRequestObjectWithMatchingCertificateHash()
+    {
+        var chain = CreateLeafSignedByCa();
+        var clientId = $"x509_hash:{LeafCertificateHash(chain.Leaf)}";
+
+        return BuildSignedRequestObject(clientId, chain, includeX5c: true);
+    }
+
+    public static string SignedRequestObjectWithMismatchedCertificateHash()
+    {
+        var chain = CreateLeafSignedByCa();
+        const string clientId = "x509_hash:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        return BuildSignedRequestObject(clientId, chain, includeX5c: true);
+    }
+
+    public static string SignedRequestObjectWithoutX5c()
+    {
+        var chain = CreateLeafSignedByCa();
+        const string clientId = "x509_hash:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        return BuildSignedRequestObject(clientId, chain, includeX5c: false);
+    }
+
+    private static string LeafCertificateHash(X509Certificate2 leaf)
+    {
+        var hash = SHA256.HashData(leaf.RawData);
+        return Base64UrlEncoder.Encode(hash);
+    }
+
+    private static string BuildSignedRequestObject(string clientId, CertificateChain chain, bool includeX5c)
+    {
+        var signingCredentials = new SigningCredentials(
+            new RsaSecurityKey(chain.LeafKey),
+            SecurityAlgorithms.RsaSha256);
+
+        var header = new JwtHeader(signingCredentials);
+        if (includeX5c)
+        {
+            header["x5c"] = new[]
+            {
+                Convert.ToBase64String(chain.Leaf.RawData),
+                Convert.ToBase64String(chain.Ca.RawData)
+            };
+        }
+
+        var payload = new JwtPayload
+        {
+            { "response_uri", ResponseUri },
+            { "client_id", clientId },
+            { "nonce", "test-nonce-value" },
+            { "response_mode", "direct_post.jwt" }
+        };
+
+        var token = new JwtSecurityToken(header, payload);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private static CertificateChain CreateLeafSignedByCa()
+    {
+        var caKey = RSA.Create(2048);
+        var caRequest = new CertificateRequest(
+            "CN=Test CA",
+            caKey,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        caRequest.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+        var caCertificate = caRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddYears(1));
+
+        var leafKey = RSA.Create(2048);
+        var leafRequest = new CertificateRequest(
+            "CN=verifier.example.com",
+            leafKey,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        leafRequest.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+
+        var serialNumber = new byte[8];
+        RandomNumberGenerator.Fill(serialNumber);
+        var leafCertificate = leafRequest.Create(
+            caCertificate,
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddMonths(6),
+            serialNumber);
+
+        return new CertificateChain(leafCertificate, leafKey, caCertificate);
+    }
+
+    private sealed record CertificateChain(X509Certificate2 Leaf, RSA LeafKey, X509Certificate2 Ca);
+}

--- a/test/WalletFramework.Oid4Vp.Tests/AuthRequest/UnresolvedClientIdSchemeTests.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/AuthRequest/UnresolvedClientIdSchemeTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using FluentAssertions;
+using LanguageExt;
+using Moq;
+using Moq.Protected;
+using WalletFramework.Core.Functional;
+using WalletFramework.Oid4Vp.Models;
+using WalletFramework.Oid4Vp.RelyingPartyAuthentication;
+using WalletFramework.Oid4Vp.RelyingPartyAuthentication.Abstractions;
+using WalletFramework.Oid4Vp.Services;
+using static WalletFramework.Oid4Vp.Tests.AuthRequest.Samples.UnresolvedClientIdSchemeSamples;
+
+namespace WalletFramework.Oid4Vp.Tests.AuthRequest;
+
+public class UnresolvedClientIdSchemeTests
+{
+    private const string RequestUri = "https://verifier.example.com/request";
+    private const string ResponseUri = "https://verifier.example.com/response";
+
+    [Fact]
+    public async Task A_Referenced_Request_Without_A_Client_Id_Is_Refused_As_Unsupported()
+    {
+        var service = CreateServiceReturning(RequestObjectWithoutClientId());
+
+        var result = await service.GetAuthorizationRequest(ReferenceUri());
+
+        CancellationOf(result).Errors.Should().ContainSingle()
+            .Which.Message.Should().Contain("is not supported");
+    }
+
+    [Fact]
+    public async Task A_Referenced_Request_With_An_Unsupported_Client_Id_Prefix_Is_Refused_As_Unsupported()
+    {
+        var service = CreateServiceReturning(RequestObjectWithUnsupportedClientIdPrefix());
+
+        var result = await service.GetAuthorizationRequest(ReferenceUri());
+
+        CancellationOf(result).Errors.Should().ContainSingle()
+            .Which.Message.Should().Contain("is not supported");
+    }
+
+    [Fact]
+    public async Task A_Request_By_Value_With_An_Unsupported_Client_Id_Prefix_Is_Refused_As_Unsupported()
+    {
+        var service = CreateServiceReturning("unused");
+
+        var result = await service.GetAuthorizationRequest(ValueUriWithUnsupportedClientIdPrefix());
+
+        CancellationOf(result).Errors.Should().ContainSingle()
+            .Which.Message.Should().Contain("is not supported");
+    }
+
+    private static AuthorizationRequestCancellation CancellationOf(
+        Validation<AuthorizationRequestCancellation, AuthorizationRequest> result) =>
+        result.Match(
+            _ => throw new InvalidOperationException("Expected a cancellation but the request succeeded"),
+            failures => failures.First());
+
+    private static AuthorizationRequestUri ReferenceUri()
+    {
+        var uri = new Uri($"openid4vp://?client_id=x509_hash:placeholder&request_uri={Uri.EscapeDataString(RequestUri)}");
+        return AuthorizationRequestUri.FromUri(uri).UnwrapOrThrow();
+    }
+
+    private static AuthorizationRequestUri ValueUriWithUnsupportedClientIdPrefix()
+    {
+        var query =
+            "client_id=unknown_scheme:verifier.example.com" +
+            "&nonce=test-nonce-value" +
+            "&scope=openid" +
+            "&response_mode=direct_post.jwt" +
+            $"&response_uri={Uri.EscapeDataString(ResponseUri)}";
+
+        var uri = new Uri($"openid4vp://?{query}");
+        return AuthorizationRequestUri.FromUri(uri).UnwrapOrThrow();
+    }
+
+    private static AuthorizationRequestService CreateServiceReturning(string requestObjectJwt)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(requestObjectJwt)
+            });
+
+        var httpClientFactory = new Mock<IHttpClientFactory>();
+        httpClientFactory
+            .Setup(factory => factory.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler.Object));
+
+        var rpAuthService = new Mock<IRpAuthService>();
+        rpAuthService
+            .Setup(service => service.Authenticate(It.IsAny<RequestObject>()))
+            .ReturnsAsync(RpAuthResult.GetWithLevelUnknown());
+
+        return new AuthorizationRequestService(httpClientFactory.Object, rpAuthService.Object);
+    }
+}

--- a/test/WalletFramework.Oid4Vp.Tests/AuthRequest/UnresolvedClientIdSchemeTests.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/AuthRequest/UnresolvedClientIdSchemeTests.cs
@@ -1,13 +1,8 @@
-using System.Net;
 using FluentAssertions;
 using LanguageExt;
-using Moq;
-using Moq.Protected;
 using WalletFramework.Core.Functional;
 using WalletFramework.Oid4Vp.Models;
-using WalletFramework.Oid4Vp.RelyingPartyAuthentication;
-using WalletFramework.Oid4Vp.RelyingPartyAuthentication.Abstractions;
-using WalletFramework.Oid4Vp.Services;
+using static WalletFramework.Oid4Vp.Tests.AuthRequest.AuthorizationRequestServiceFactory;
 using static WalletFramework.Oid4Vp.Tests.AuthRequest.Samples.UnresolvedClientIdSchemeSamples;
 
 namespace WalletFramework.Oid4Vp.Tests.AuthRequest;
@@ -58,7 +53,7 @@ public class UnresolvedClientIdSchemeTests
 
     private static AuthorizationRequestUri ReferenceUri()
     {
-        var uri = new Uri($"openid4vp://?client_id=x509_hash:placeholder&request_uri={Uri.EscapeDataString(RequestUri)}");
+        var uri = new Uri($"openid4vp://?client_id={ClientIdScheme.X509HashScheme}:placeholder&request_uri={Uri.EscapeDataString(RequestUri)}");
         return AuthorizationRequestUri.FromUri(uri).UnwrapOrThrow();
     }
 
@@ -73,32 +68,5 @@ public class UnresolvedClientIdSchemeTests
 
         var uri = new Uri($"openid4vp://?{query}");
         return AuthorizationRequestUri.FromUri(uri).UnwrapOrThrow();
-    }
-
-    private static AuthorizationRequestService CreateServiceReturning(string requestObjectJwt)
-    {
-        var handler = new Mock<HttpMessageHandler>();
-        handler
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(requestObjectJwt)
-            });
-
-        var httpClientFactory = new Mock<IHttpClientFactory>();
-        httpClientFactory
-            .Setup(factory => factory.CreateClient(It.IsAny<string>()))
-            .Returns(() => new HttpClient(handler.Object));
-
-        var rpAuthService = new Mock<IRpAuthService>();
-        rpAuthService
-            .Setup(service => service.Authenticate(It.IsAny<RequestObject>()))
-            .ReturnsAsync(RpAuthResult.GetWithLevelUnknown());
-
-        return new AuthorizationRequestService(httpClientFactory.Object, rpAuthService.Object);
     }
 }

--- a/test/WalletFramework.Oid4Vp.Tests/AuthRequest/X509HashRequestProcessingTests.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/AuthRequest/X509HashRequestProcessingTests.cs
@@ -1,12 +1,7 @@
-using System.Net;
 using FluentAssertions;
-using Moq;
-using Moq.Protected;
 using WalletFramework.Core.Functional;
 using WalletFramework.Oid4Vp.Models;
-using WalletFramework.Oid4Vp.RelyingPartyAuthentication;
-using WalletFramework.Oid4Vp.RelyingPartyAuthentication.Abstractions;
-using WalletFramework.Oid4Vp.Services;
+using static WalletFramework.Oid4Vp.Tests.AuthRequest.AuthorizationRequestServiceFactory;
 using static WalletFramework.Oid4Vp.Tests.AuthRequest.Samples.X509HashSamples;
 
 namespace WalletFramework.Oid4Vp.Tests.AuthRequest;
@@ -37,34 +32,7 @@ public class X509HashRequestProcessingTests
 
     private static AuthorizationRequestUri ReferenceUri()
     {
-        var uri = new Uri($"openid4vp://?client_id=x509_hash:placeholder&request_uri={Uri.EscapeDataString(RequestUri)}");
+        var uri = new Uri($"openid4vp://?client_id={ClientIdScheme.X509HashScheme}:placeholder&request_uri={Uri.EscapeDataString(RequestUri)}");
         return AuthorizationRequestUri.FromUri(uri).UnwrapOrThrow();
-    }
-
-    private static AuthorizationRequestService CreateServiceReturning(string requestObjectJwt)
-    {
-        var handler = new Mock<HttpMessageHandler>();
-        handler
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(requestObjectJwt)
-            });
-
-        var httpClientFactory = new Mock<IHttpClientFactory>();
-        httpClientFactory
-            .Setup(factory => factory.CreateClient(It.IsAny<string>()))
-            .Returns(() => new HttpClient(handler.Object));
-
-        var rpAuthService = new Mock<IRpAuthService>();
-        rpAuthService
-            .Setup(service => service.Authenticate(It.IsAny<RequestObject>()))
-            .ReturnsAsync(RpAuthResult.GetWithLevelUnknown());
-
-        return new AuthorizationRequestService(httpClientFactory.Object, rpAuthService.Object);
     }
 }

--- a/test/WalletFramework.Oid4Vp.Tests/AuthRequest/X509HashRequestProcessingTests.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/AuthRequest/X509HashRequestProcessingTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using WalletFramework.Core.Functional;
+using WalletFramework.Oid4Vp.Models;
+using WalletFramework.Oid4Vp.RelyingPartyAuthentication;
+using WalletFramework.Oid4Vp.RelyingPartyAuthentication.Abstractions;
+using WalletFramework.Oid4Vp.Services;
+using static WalletFramework.Oid4Vp.Tests.AuthRequest.Samples.X509HashSamples;
+
+namespace WalletFramework.Oid4Vp.Tests.AuthRequest;
+
+public class X509HashRequestProcessingTests
+{
+    private const string RequestUri = "https://verifier.example.com/request";
+
+    [Fact]
+    public async Task A_Signed_Request_With_A_Matching_Certificate_Hash_Is_Processed_Successfully()
+    {
+        var service = CreateServiceReturning(SignedRequestObjectWithMatchingCertificateHash());
+
+        var result = await service.GetAuthorizationRequest(ReferenceUri());
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_Signed_Request_With_A_Mismatched_Certificate_Hash_Is_Cancelled_Without_Throwing()
+    {
+        var service = CreateServiceReturning(SignedRequestObjectWithMismatchedCertificateHash());
+
+        var result = await service.GetAuthorizationRequest(ReferenceUri());
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    private static AuthorizationRequestUri ReferenceUri()
+    {
+        var uri = new Uri($"openid4vp://?client_id=x509_hash:placeholder&request_uri={Uri.EscapeDataString(RequestUri)}");
+        return AuthorizationRequestUri.FromUri(uri).UnwrapOrThrow();
+    }
+
+    private static AuthorizationRequestService CreateServiceReturning(string requestObjectJwt)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(requestObjectJwt)
+            });
+
+        var httpClientFactory = new Mock<IHttpClientFactory>();
+        httpClientFactory
+            .Setup(factory => factory.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler.Object));
+
+        var rpAuthService = new Mock<IRpAuthService>();
+        rpAuthService
+            .Setup(service => service.Authenticate(It.IsAny<RequestObject>()))
+            .ReturnsAsync(RpAuthResult.GetWithLevelUnknown());
+
+        return new AuthorizationRequestService(httpClientFactory.Object, rpAuthService.Object);
+    }
+}

--- a/test/WalletFramework.Oid4Vp.Tests/AuthRequest/X509HashTests.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/AuthRequest/X509HashTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using LanguageExt;
+using WalletFramework.Core.Functional;
+using WalletFramework.Oid4Vp.Models;
+using static WalletFramework.Oid4Vp.Tests.AuthRequest.Samples.X509HashSamples;
+
+namespace WalletFramework.Oid4Vp.Tests.AuthRequest;
+
+public class X509HashTests
+{
+    [Fact]
+    public void Request_Object_With_The_X509_Hash_Prefix_Is_Recognized_As_The_X509_Hash_Scheme()
+    {
+        var requestObject = RequestObject
+            .FromStr(SignedRequestObjectWithMatchingCertificateHash(), Option<string>.None)
+            .UnwrapOrThrow();
+
+        var scheme = requestObject.ClientIdScheme.Value;
+
+        scheme.Should().Be(ClientIdScheme.ClientIdSchemeValue.X509Hash);
+    }
+
+    [Fact]
+    public void A_Client_Id_Hash_Matching_The_Leaf_Certificate_Is_Accepted()
+    {
+        var requestObject = RequestObject
+            .FromStr(SignedRequestObjectWithMatchingCertificateHash(), Option<string>.None)
+            .UnwrapOrThrow();
+
+        var sut = requestObject.ValidateCertificateHash();
+
+        sut.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void A_Client_Id_Hash_Not_Matching_The_Leaf_Certificate_Is_Rejected()
+    {
+        var requestObject = RequestObject
+            .FromStr(SignedRequestObjectWithMismatchedCertificateHash(), Option<string>.None)
+            .UnwrapOrThrow();
+
+        var validateMismatchedHash = () => requestObject.ValidateCertificateHash();
+
+        validateMismatchedHash.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void A_Request_Object_Without_Certificates_Is_Rejected()
+    {
+        var requestObject = RequestObject
+            .FromStr(SignedRequestObjectWithoutX5c(), Option<string>.None)
+            .UnwrapOrThrow();
+
+        var validateWithoutCertificates = () => requestObject.ValidateCertificateHash();
+
+        validateWithoutCertificates.Should().Throw<Exception>();
+    }
+}


### PR DESCRIPTION
## Summary
  Adds HAIP 1.0 conformance support for OID4VP/OID4VCI flows.

  This PR:
  - Adds support for the `x509_hash` client ID scheme and validates request objects
  against the SHA-256 hash of the leaf certificate.
  - Improves unsupported/invalid client ID scheme handling so invalid requests return
  structured `invalid_request` cancellations instead of leaking validation
  exceptions.
  - Adds HAIP-compatible metadata discovery URL construction for credential issuer
  and authorization server metadata.
  - Preserves original issuer and authorization server identifiers when stringifying
  IDs.
  - Adds unit coverage for `x509_hash`, unresolved client ID schemes, metadata
  discovery URLs, issuer metadata processing, and issuer/authorization server ID
  formatting.

  ### Related Issue(s)
  N/A

  ## Checklist
  - [x] No secrets, credentials, or sensitive data are added
  - [x] CHANGELOG.md updated under [Unreleased] with correct category and links
  according to [CONTRIBUTING.md](../CONTRIBUTING.md)
  - [ ] [README.md](../README.md) updated if applicable
  - [x] (Unit) Tests added if applicable
