### PR TITLE
Fix SD-JWT credential usage without KeyBinding

### DIFF
--- a/src/WalletFramework.SdJwtVc/Persistence/SdJwtCredentialRecord.cs
+++ b/src/WalletFramework.SdJwtVc/Persistence/SdJwtCredentialRecord.cs
@@ -53,7 +53,7 @@ public record SdJwtCredentialRecord : RecordBase
     {
         var credentialId = CredentialId.ValidCredentialId(RecordId.ToString()).UnwrapOrThrow();
         var setId = Core.Credentials.CredentialSetId.ValidCredentialSetId(CredentialSetId).UnwrapOrThrow();
-        var keyId = Core.Cryptography.Models.KeyId.ValidKeyId(KeyId).UnwrapOrThrow();
+        var keyId = KeyId.AsOption().OnSome(keyId => Core.Cryptography.Models.KeyId.ValidKeyId(keyId).ToOption());
         var state = Enum.Parse<CredentialState>(CredentialState);
         var expires = ExpiresAt is null ? Option<DateTime>.None : Option<DateTime>.Some(ExpiresAt.Value);
 


### PR DESCRIPTION
## Problem

`SdJwtCredentialRecord.ToDomainModel` unconditionally unwrapped the `KeyId` validation via `UnwrapOrThrow`, so loading a persisted SD-JWT credential without KeyBinding (where `KeyId` is `null`) threw an exception.

## Fix

Treat a missing `KeyId` as `Option.None` so keyless credentials hydrate correctly from persistence.