### PR TITLE
fix(oid4vp): align transaction data hashes with OID4VP 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SD-JWT presentations include the right disclosures for nested and array-shaped claims, not only simple top-level paths.
 - Fixed crash when resolving credential state from a status list: malformed JWT payloads, invalid base64, zlib/deflate errors, and out-of-range indices are handled by returning no state instead of throwing
 - Fix the usage of SD-JWT credentials without HolderBinding
+- Transaction data hashes are computed over the base64url string as received and encoded as base64url, as required by OID4VP 1.0.
 
 #### Changed
 

--- a/src/WalletFramework.Oid4Vp/Services/PresentationService.cs
+++ b/src/WalletFramework.Oid4Vp/Services/PresentationService.cs
@@ -72,8 +72,8 @@ public class PresentationService : IPresentationService
                     });
                 });
 
-            var txDataHashesAsHexOption = txDataHashesOption
-                .OnSome(hashes => hashes.Select(hash => hash.AsHex));
+            var txDataHashesAsBase64UrlOption = txDataHashesOption
+                .OnSome(hashes => hashes.Select(hash => hash.AsBase64Url));
 
             var txDataHashesAlgOption = txDataHashesOption
                 .OnSome(hashes => hashes.First().Alg.AsString);
@@ -104,7 +104,7 @@ public class PresentationService : IPresentationService
                     presentation = await _sdJwtVcHolderService.CreatePresentation(
                         sdJwt,
                         sdJwtPaths,
-                        txDataHashesAsHexOption,
+                        txDataHashesAsBase64UrlOption,
                         txDataHashesAlgOption,
                         audience,
                         authorizationRequest.Nonce);

--- a/src/WalletFramework.Oid4Vp/TransactionDatas/TransactionDataHash.cs
+++ b/src/WalletFramework.Oid4Vp/TransactionDatas/TransactionDataHash.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using WalletFramework.Core.Base64Url;
 using WalletFramework.Core.Encoding;
 
 namespace WalletFramework.Oid4Vp.TransactionDatas;
@@ -10,9 +12,9 @@ namespace WalletFramework.Oid4Vp.TransactionDatas;
 public readonly struct TransactionDataHash(Sha256Hash hash, TransactionDataHashesAlg alg)
 {
     public TransactionDataHashesAlg Alg { get; } = alg;
-    
-    public string AsHex => hash.AsHex;
-}    
+
+    public string AsBase64Url => Base64UrlString.CreateBase64UrlString(hash.AsBytes).AsString;
+}
 
 public static class TransactionDataHashFun
 {
@@ -20,7 +22,7 @@ public static class TransactionDataHashFun
     {
         var hashWith256 = new Func<TransactionData, TransactionDataHash>(data =>
         {
-            var bytes = data.GetEncoded().AsByteArray;
+            var bytes = Encoding.UTF8.GetBytes(data.GetEncoded().AsString);
             var hash = Sha256Hash.ComputeHash(bytes);
             return new TransactionDataHash(hash, TransactionDataHashesAlg.Sha256);
         });

--- a/test/WalletFramework.Oid4Vp.Tests/Dcql/Samples/TransactionDataSamples.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/Dcql/Samples/TransactionDataSamples.cs
@@ -8,6 +8,8 @@ public static class TransactionDataSamples
     public const string PaymentTransactionDataForPid =
         "eyJwYXltZW50X2RhdGEiOnsicGF5ZWUiOiJBQkMgQmFuayIsImN1cnJlbmN5X2Ftb3VudCI6eyJjdXJyZW5jeSI6IkVVUiIsInZhbHVlIjoiODAwIn19LCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOlsic2hhLTI1NiJdLCJjcmVkZW50aWFsX2lkcyI6WyJwaWQiXSwidHlwZSI6InBheW1lbnRfZGF0YSJ9";
 
+    public const string PaymentTransactionDataForPidHash = "LSmXQMjCLNV24gObvbOOrJQVgBZLhg0yO8zaqgB0S3w";
+
     private const string AuthRequestWithTransactionDataTemplate = @"{
   ""response_uri"": ""https://test.test.test.io/openid4vp/authorization-response"",
   ""transaction_data"": [

--- a/test/WalletFramework.Oid4Vp.Tests/TS12SCA/Ts12PaymentTransactionDataTests.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/TS12SCA/Ts12PaymentTransactionDataTests.cs
@@ -1,7 +1,9 @@
+using System.Text;
 using FluentAssertions;
 using LanguageExt;
 using Moq;
 using Newtonsoft.Json.Linq;
+using WalletFramework.Core.Base64Url;
 using WalletFramework.Core.ClaimPaths;
 using WalletFramework.Core.Credentials.Abstractions;
 using WalletFramework.Core.Encoding;
@@ -117,14 +119,14 @@ public class Ts12PaymentTransactionDataTests
         var sample = Ts12PaymentTransactionDataSamples.GetBase64UrlString(originalJson);
         var reserializedJson = JObject.Parse(originalJson).ToString(Newtonsoft.Json.Formatting.None);
         var reserializedSample = Ts12PaymentTransactionDataSamples.GetBase64UrlString(reserializedJson);
-        var expectedHash = Sha256Hash.ComputeHash(sample.AsByteArray).AsHex;
-        var reserializedHash = Sha256Hash.ComputeHash(reserializedSample.AsByteArray).AsHex;
+        var expectedHash = HashOfEncodedString(sample);
+        var reserializedHash = HashOfEncodedString(reserializedSample);
 
         var sut = TransactionData.FromBase64Url(sample).UnwrapOrThrow();
 
         sut.AsT3.TransactionDataProperties.Encoded.Should().Be(sample);
-        sut.Hash(TransactionDataHashesAlg.Sha256).AsHex.Should().Be(expectedHash);
-        sut.Hash(TransactionDataHashesAlg.Sha256).AsHex.Should().NotBe(reserializedHash);
+        sut.Hash(TransactionDataHashesAlg.Sha256).AsBase64Url.Should().Be(expectedHash);
+        sut.Hash(TransactionDataHashesAlg.Sha256).AsBase64Url.Should().NotBe(reserializedHash);
     }
 
     [Fact]
@@ -217,7 +219,7 @@ public class Ts12PaymentTransactionDataTests
             credential,
             Option<List<ClaimQuery>>.None,
             new List<TransactionData> { transactionData });
-        var expectedHash = transactionData.Hash(TransactionDataHashesAlg.Sha256).AsHex;
+        var expectedHash = transactionData.Hash(TransactionDataHashesAlg.Sha256).AsBase64Url;
         Option<IEnumerable<string>> capturedHashes = Option<IEnumerable<string>>.None;
         Option<string> capturedHashesAlg = Option<string>.None;
         var sdJwtVcHolderService = new Mock<ISdJwtVcHolderService>();
@@ -250,4 +252,11 @@ public class Ts12PaymentTransactionDataTests
             alg => alg.Should().Be("sha-256"),
             () => Assert.Fail("Expected transaction_data_hashes_alg to be present"));
     }
+
+    // sha-256 over the ASCII bytes of the base64url string itself (no decoding before hashing),
+    // encoded as base64url per OID4VP 1.0 B.3.3.1
+    private static string HashOfEncodedString(Base64UrlString encoded) =>
+        Base64UrlString
+            .CreateBase64UrlString(Sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(encoded.AsString)).AsBytes)
+            .AsString;
 }

--- a/test/WalletFramework.Oid4Vp.Tests/TransactionDatas/TransactionDataTests.cs
+++ b/test/WalletFramework.Oid4Vp.Tests/TransactionDatas/TransactionDataTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
+using WalletFramework.Core.Base64Url;
 using WalletFramework.Core.Credentials.Abstractions;
+using WalletFramework.Core.Functional;
 using WalletFramework.Oid4Vp.Dcql;
 using WalletFramework.Oid4Vp.Models;
 using WalletFramework.Oid4Vp.Tests.Dcql.Samples;
@@ -10,6 +12,20 @@ namespace WalletFramework.Oid4Vp.Tests.TransactionDatas;
 
 public class TransactionDataTests
 {
+    [Fact]
+    public void Hash_Is_Computed_Over_The_Encoded_String_And_Base64Url_Encoded()
+    {
+        var encoded = Base64UrlString
+            .FromString(TransactionDataSamples.PaymentTransactionDataForPid)
+            .UnwrapOrThrow();
+
+        var transactionData = TransactionData.FromBase64Url(encoded).UnwrapOrThrow();
+
+        var hash = transactionData.Hash(TransactionDataHashesAlg.Sha256);
+
+        hash.AsBase64Url.Should().Be(TransactionDataSamples.PaymentTransactionDataForPidHash);
+    }
+
     [Fact]
     public void Transaction_Data_Are_Matched_To_Candidate_Correctly()
     {


### PR DESCRIPTION
## Summary

Transaction data hashes did not conform to OID4VP 1.0 B.3.3.1 in two ways: they were computed over the base64url-*decoded* bytes rather than the base64url string as received, and returned as hex rather than base64url. Either alone makes `transaction_data_hashes` unverifiable by a conforming verifier.

`TransactionDataHash.AsHex` becomes `AsBase64Url`, which `PresentationService` passes into the SD-JWT presentation. For the payment test sample: `xDGmrkgl…UWH-8` before, `LSmXQMjC…B0S3w` after.

A new test pins the algorithm to a golden value reproducible outside this codebase, stored next to the sample it hashes. The TS12 encoding-preservation test is carried over to the new semantics.

### Related Issue(s)

None.

## Checklist
- [x] No secrets, credentials, or sensitive data are added
- [x] CHANGELOG.md updated — under `[3.1.0]` → Fixed, since this targets the release branch
- [ ] README.md updated if applicable — n/a
- [x] (Unit) Tests added if applicable

`CONTRIBUTING.md` routes regular bugfixes to `develop`; targeted here because the defect is in the 3.1.0 OID4VP work. Happy to retarget.